### PR TITLE
WIP: custom parser implementation

### DIFF
--- a/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerParser.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerParser.java
@@ -1,0 +1,335 @@
+package com.github.jimschubert.rewrite.docker.internal;
+
+import com.github.jimschubert.rewrite.docker.tree.Docker;
+import com.github.jimschubert.rewrite.docker.tree.DockerRightPadded;
+import com.github.jimschubert.rewrite.docker.tree.Quoting;
+import com.github.jimschubert.rewrite.docker.tree.Space;
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+
+import java.io.InputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+
+public class DockerParser {
+    // InstructionParser is used to collect the parts of an instruction and parse it into the appropriate AST node.
+    static class InstructionParser {
+        private Space prefix = Space.EMPTY;
+        private Space rightPadding = Space.EMPTY;
+        private Quoting quoting = Quoting.UNQUOTED;
+        private char escapeChar = 0x5C; // backslash
+        private Class<? extends Docker.Instruction> instructionType = null;
+
+        private final StringBuilder instruction = new StringBuilder();
+
+        String getEscapeChar() {
+            return String.valueOf(escapeChar);
+        }
+
+        void appendPrefix(Space prefix) {
+            if (prefix != null) {
+                this.prefix = prefix.withWhitespace(this.prefix.getWhitespace() + prefix.getWhitespace());
+            }
+        }
+
+        void append(String s) {
+            instruction.append(s);
+        }
+
+        void reset(){
+            instructionType = null;
+            prefix = Space.EMPTY;
+            rightPadding = Space.EMPTY;
+            quoting = Quoting.UNQUOTED;
+            instruction.setLength(0);
+        }
+
+        Docker.KeyArgs stringToKeyArgs(String s) {
+            if (s == null || s.isEmpty()) {
+                return null;
+            }
+
+            StringWithPrefix stringWithPrefix = getResult(s);
+            String content = stringWithPrefix.content();
+
+            @SuppressWarnings("RegExpRepeatedSpace")
+            String delim = content.contains("=") ? "=" : " ";
+            String[] parts = content.split(delim, "=".equals(delim) ? 2 : 0);
+            String key = parts.length > 0 ? parts[0] : "";
+            String value = parts.length > 1 ? parts[1].trim() : null;
+            Quoting q = Quoting.UNQUOTED;
+
+            if (value != null) {
+                if (value.startsWith("\"") && value.endsWith("\"")) {
+                    q = Quoting.DOUBLE_QUOTED;
+                    value = value.substring(1, value.length() - 1);
+                } else if (value.startsWith("'") && value.endsWith("'")) {
+                    q = Quoting.SINGLE_QUOTED;
+                    value = value.substring(1, value.length() - 1);
+                }
+            }
+            return new Docker.KeyArgs(stringWithPrefix.prefix(), key, value, "=".equals(delim), q);
+        }
+
+        private Docker.Literal createLiteral(String s) {
+            return new Docker.Literal(Tree.randomId(), prefix, s, Markers.EMPTY);
+        }
+
+        private Docker.Option createOption(String s) {
+            String[] parts = s.split("=", 2);
+            String key = parts.length > 0 ? parts[0] : "";
+            String value = parts.length > 1 ? parts[1] : "";
+            return new Docker.Option(Tree.randomId(), prefix, key, List.of(stringToKeyArgs(value)), Markers.EMPTY);
+        }
+
+        Docker.Instruction parse() {
+            String name = instructionType.getSimpleName();
+            if (name.equals(Docker.Add.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.Add(Tree.randomId(), prefix, Markers.EMPTY, null, null, null);
+            } else if (name.equals(Docker.Arg.class.getSimpleName())) {
+                return new Docker.Arg(Tree.randomId(), prefix, Markers.EMPTY, List.of(DockerRightPadded.build(stringToKeyArgs(instruction.toString()))));
+            } else if (name.equals(Docker.Cmd.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.Cmd(Tree.randomId(), prefix, Markers.EMPTY, null, null);
+            } else if (name.equals(Docker.Comment.class.getSimpleName())) {
+                StringWithPrefix stringWithPrefix = getResult(instruction.toString());
+
+                return new Docker.Comment(Tree.randomId(), prefix, Markers.EMPTY,
+                        DockerRightPadded.build(createLiteral(stringWithPrefix.content()).withPrefix(stringWithPrefix.prefix())).withAfter(rightPadding));
+            } else if (name.equals(Docker.Copy.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.Copy(Tree.randomId(), prefix, Markers.EMPTY, null, null, null);
+            } else if (name.equals(Docker.Directive.class.getSimpleName())) {
+                StringWithPrefix stringWithPrefix = getResult(instruction.toString());
+
+                String[] parts = stringWithPrefix.content().split("=", 2);
+                String key = parts.length > 0 ? parts[0] : "";
+                String value = parts.length > 1 ? parts[1] : "";
+
+                if ( key.equalsIgnoreCase("escape")) {
+                    escapeChar = value.charAt(0);
+                }
+
+                return new Docker.Directive(Tree.randomId(), prefix, Markers.EMPTY, new DockerRightPadded<>(
+                        new Docker.KeyArgs(stringWithPrefix.prefix, key, value, true, quoting),
+                        rightPadding,
+                        Markers.EMPTY
+                ));
+            } else if (name.equals(Docker.Entrypoint.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.Entrypoint(Tree.randomId(), prefix, Markers.EMPTY, null, null);
+            } else if (name.equals(Docker.Env.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.Env(Tree.randomId(), prefix, Markers.EMPTY, null);
+            }  else if (name.equals(Docker.Expose.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.Expose(Tree.randomId(), prefix, Markers.EMPTY, null);
+            } else if (name.equals(Docker.From.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.From(Tree.randomId(), prefix, Markers.EMPTY, null, null, null, null, null);
+            } else if (name.equals(Docker.Healthcheck.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.Healthcheck(Tree.randomId(), prefix, Markers.EMPTY, null, null, null);
+            } else if (name.equals(Docker.Label.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.Label(Tree.randomId(), prefix, Markers.EMPTY, null);
+            } else if (name.equals(Docker.Maintainer.class.getSimpleName())) {
+                return new Docker.Maintainer (Tree.randomId(), prefix, Markers.EMPTY, instruction.toString(), quoting);
+            } else if (name.equals(Docker.OnBuild.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.OnBuild(Tree.randomId(), prefix, Markers.EMPTY, null);
+            }  else if (name.equals(Docker.Run.class.getSimpleName())) {
+                List<String> commands = new ArrayList<>();
+                if (instruction.toString().contains(escapeChar + "\n")) {
+                    Space indent = Space.EMPTY;
+                    String[] parts = instruction.toString().split(escapeChar + "\\n");
+                    if (parts.length > 1) {
+                        // collect all leading whitespace of the first part
+                        int idx = 0;
+                        for (char c : parts[0].toCharArray()) {
+                            if (c == ' ' || c == '\t') {
+                                idx++;
+                                indent = indent.withWhitespace(indent.getWhitespace() + c);
+                            } else {
+                                break;
+                            }
+                        }
+                        commands.add(parts[0].substring(idx));
+                    }
+                } else {
+                    commands.add(instruction.toString());
+                }
+
+                // TODO: implement this Options should be a list of KeyArgs, Commands should be a list of RightPadded literals
+                return new Docker.Run(Tree.randomId(), prefix, Markers.EMPTY, null, null, null, null, null, null);
+            } else if (name.equals(Docker.Shell.class.getSimpleName())) {
+                List<String> commands = new ArrayList<>();
+                if (instruction.toString().contains(escapeChar + "\n")) {
+                    Space indent = Space.EMPTY;
+                    String[] parts = instruction.toString().split(escapeChar + "\\n");
+                    if (parts.length > 1) {
+                        // collect all leading whitespace of the first part
+                        int idx = 0;
+                        for (char c : parts[0].toCharArray()) {
+                            if (c == ' ' || c == '\t') {
+                                idx++;
+                                indent = indent.withWhitespace(indent.getWhitespace() + c);
+                            } else {
+                                break;
+                            }
+                        }
+                        commands.add(parts[0].substring(idx));
+                    }
+                } else {
+                    commands.add(instruction.toString());
+                }
+
+                return new Docker.Shell(Tree.randomId(), prefix, Markers.EMPTY, commands);
+            }else if (name.equals(Docker.StopSignal.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.StopSignal(Tree.randomId(), prefix, Markers.EMPTY, null);
+            } else if (name.equals(Docker.User.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.User(Tree.randomId(), prefix, Markers.EMPTY, null, null);
+            } else if (name.equals(Docker.Volume.class.getSimpleName())) {
+                return new Docker.Volume(Tree.randomId(), prefix, Markers.EMPTY, instruction.toString());
+            } else if (name.equals(Docker.Workdir.class.getSimpleName())) {
+                // TODO: implement this
+                return new Docker.Workdir(Tree.randomId(), prefix, Markers.EMPTY, null);
+            }
+            return null;
+        }
+
+        private @NotNull DockerParser.InstructionParser.StringWithPrefix getResult(String content) {
+            int idx = 0;
+            for (char c : content.toCharArray()) {
+                if (c == ' ' || c == '\t') {
+                    idx++;
+                } else {
+                    break;
+                }
+            }
+
+            Space before = Space.build(content.substring(0, idx));
+            content = content.substring(idx);
+            return new StringWithPrefix(content, before);
+        }
+
+        private record StringWithPrefix(String content, Space prefix) { }
+    }
+
+    public Docker parse(InputStream input) {
+        // scan the input stream and maintain state. A newline is the delimiter for a complete instruction unless escaped.
+        // when a complete instruction is found, parse it into an AST node
+        List<Docker.Stage> stages = new ArrayList<>();
+        List<Docker.Instruction> currentInstructions = new ArrayList<>();
+
+        Space eof = Space.EMPTY;
+        List<Docker.Instruction> parsed = new ArrayList<>();
+        InstructionParser parser = new InstructionParser();
+
+        try (Scanner scanner = new Scanner(input)) {
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine();
+                if (line.isEmpty()) {
+                    // tracks newlines for continuations and prefixes
+                    parser.appendPrefix(Space.build("\n"));
+                    continue;
+                }
+
+                // drain the line of any leading whitespace, storing in parser.addPrefix, then inspect the first "word" to determine the instruction type
+                while (line.startsWith(" ") || line.startsWith("\t")) {
+                    parser.appendPrefix(Space.build(line.substring(0, 1)));
+                    line = line.substring(1);
+                }
+
+                if (line.isEmpty()) {
+                    continue;
+                }
+
+                // take line until the first space character
+                int spaceIndex = line.indexOf(' ');
+                String firstWord = (spaceIndex == -1) ? line : line.substring(0, spaceIndex);
+
+                parser.instructionType = instructionFromText(firstWord);
+
+                // remove the first word from line
+                line = (spaceIndex == -1) ? line : line.substring(spaceIndex);
+
+                int idx = line.length() - 1;
+                // walk line backwards to find the last non-whitespace character
+                for (int i = line.length() - 1; i >= 0; i--) {
+                    if (line.charAt(i) != ' ' && line.charAt(i) != '\t') {
+                        // move the pointer to after the current non-whitespace character
+                        idx = i + 1;
+                        break;
+                    }
+                }
+
+                if (idx < line.length()) {
+                    parser.rightPadding = Space.build(line.substring(idx));
+                    line = line.substring(0, idx);
+                }
+
+                String escapeChar = parser.getEscapeChar();
+
+                if (parser.instructionType == Docker.Comment.class) {
+                    String lower = line.toLowerCase().trim();
+                    // hack: if comment is a directive, change the type accordingly
+                    // directives are used so rarely that I don't care to make this much more robust atm
+                    if ((lower.startsWith("syntax=") || lower.startsWith("escape=") || lower.startsWith("check=")) && !lower.contains(" ")) {
+                        parser.instructionType = Docker.Directive.class;
+                    }
+                }
+
+                parser.append(line);
+                if (line.endsWith(escapeChar)) {
+                    parser.append("\n");
+                    continue;
+                }
+                Docker.Instruction instr = parser.parse();
+                currentInstructions.add(instr);
+                if (instr instanceof Docker.From) {
+                    stages.add(new Docker.Stage(Tree.randomId(), Markers.EMPTY, currentInstructions));
+                    currentInstructions.clear();
+                }
+
+                parser.reset();
+            }
+        }
+
+        if (stages.isEmpty()) {
+            stages.add(new Docker.Stage(Tree.randomId(), Markers.EMPTY, currentInstructions));
+        }
+
+        return new Docker.Document(Tree.randomId(), Markers.EMPTY, Paths.get("Dockerfile"), null, null, false, null, stages, eof);
+    }
+
+    private Class<? extends Docker.Instruction> instructionFromText(String s) {
+        return switch (s.toUpperCase()) {
+            case "ADD" -> Docker.Add.class;
+            case "ARG" -> Docker.Arg.class;
+            case "CMD" -> Docker.Cmd.class;
+            case "COPY" -> Docker.Copy.class;
+            case "ENTRYPOINT" -> Docker.Entrypoint.class;
+            case "ENV" -> Docker.Env.class;
+            case "EXPOSE" -> Docker.Expose.class;
+            case "FROM" -> Docker.From.class;
+            case "HEALTHCHECK" -> Docker.Healthcheck.class;
+            case "LABEL" -> Docker.Label.class;
+            case "MAINTAINER" -> Docker.Maintainer.class;
+            case "ONBUILD" -> Docker.OnBuild.class;
+            case "RUN" -> Docker.Run.class;
+            case "SHELL" -> Docker.Shell.class;
+            case "STOPSIGNAL" -> Docker.StopSignal.class;
+            case "USER" -> Docker.User.class;
+            case "VOLUME" -> Docker.Volume.class;
+            case "WORKDIR" -> Docker.Workdir.class;
+            default -> Docker.Comment.class;
+        };
+    }
+}

--- a/src/main/java/com/github/jimschubert/rewrite/docker/internal/StringWithPadding.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/internal/StringWithPadding.java
@@ -1,0 +1,5 @@
+package com.github.jimschubert.rewrite.docker.internal;
+
+import com.github.jimschubert.rewrite.docker.tree.Space;
+
+public record StringWithPadding(String content, Space prefix, Space suffix) { }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/internal/StringWithPadding.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/internal/StringWithPadding.java
@@ -2,4 +2,36 @@ package com.github.jimschubert.rewrite.docker.internal;
 
 import com.github.jimschubert.rewrite.docker.tree.Space;
 
-public record StringWithPadding(String content, Space prefix, Space suffix) { }
+public record StringWithPadding(String content, Space prefix, Space suffix) {
+    public static StringWithPadding of(String value) {
+        int idx = 0;
+        for (char c : value.toCharArray()) {
+            if (c == ' ' || c == '\t') {
+                idx++;
+            } else {
+                break;
+            }
+        }
+
+        Space rightPadding = Space.EMPTY;
+        Space before = Space.build(value.substring(0, idx));
+        value = value.substring(idx);
+
+        idx = value.length() - 1;
+        // walk line backwards to find the last non-whitespace character
+        for (int i = value.length() - 1; i >= 0; i--) {
+            if (value.charAt(i) != ' ' && value.charAt(i) != '\t') {
+                // move the pointer to after the current non-whitespace character
+                idx = i + 1;
+                break;
+            }
+        }
+
+        if (idx < value.length()) {
+            rightPadding = Space.build(value.substring(idx));
+            value = value.substring(0, idx);
+        }
+
+        return new StringWithPadding(value, before, rightPadding);
+    }
+}

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -238,15 +238,12 @@ public interface Docker extends Tree {
     class Cmd implements Docker.Instruction {
         @EqualsAndHashCode.Include
         UUID id;
-
+        Form form;
         Space prefix;
         Space execFormPrefix;
-        Markers markers;
-
-        Form form;
         List<DockerRightPadded<Literal>> commands;
-
         Space execFormSuffix;
+        Markers markers;
 
         @Override
         public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
@@ -260,7 +257,7 @@ public interface Docker extends Tree {
 
         @Override
         public Docker copyPaste() {
-            return new Cmd(Tree.randomId(), prefix, execFormPrefix, markers, form, commands, execFormSuffix);
+            return new Cmd(Tree.randomId(), form, prefix, execFormPrefix, commands, execFormSuffix, markers);
         }
     }
 
@@ -395,13 +392,12 @@ public interface Docker extends Tree {
     class Entrypoint implements Docker.Instruction {
         @EqualsAndHashCode.Include
         UUID id;
-
+        Form form;
         Space prefix;
+        Space execFormPrefix;
+        List<DockerRightPadded<Literal>> commands;
+        Space execFormSuffix;
         Markers markers;
-
-        List<DockerRightPadded<Literal>> command;
-
-        Space trailing;
 
         @Override
         public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
@@ -415,7 +411,7 @@ public interface Docker extends Tree {
 
         @Override
         public Docker copyPaste() {
-            return new Entrypoint(Tree.randomId(), prefix, markers, command, trailing);
+            return new Entrypoint(Tree.randomId(), form, prefix,execFormPrefix, commands, execFormSuffix, markers);
         }
     }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -57,7 +57,11 @@ public interface Docker extends Tree {
 
         String text;
 
+        Space trailing;
+
         Markers markers;
+
+        Quoting quoting;
 
         @Override
         public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
@@ -71,11 +75,17 @@ public interface Docker extends Tree {
 
         @Override
         public Docker copyPaste() {
-            return new Literal(Tree.randomId(), prefix, text, markers == null ? Markers.EMPTY : Markers.build(markers.getMarkers()));
+            return new Literal(Tree.randomId(), prefix, text, trailing,
+                    markers == null ? Markers.EMPTY : Markers.build(markers.getMarkers()),
+                    quoting);
         }
 
         public static Literal build(String text) {
-            return new Literal(Tree.randomId(), Space.EMPTY, text, Markers.EMPTY);
+            return new Literal(Tree.randomId(), Space.EMPTY, text, Space.EMPTY, Markers.EMPTY, Quoting.UNQUOTED);
+        }
+
+        public static Literal build(Space prefix, String text, Space trailing, Quoting quoting) {
+            return new Literal(Tree.randomId(), prefix, text, trailing, Markers.EMPTY, quoting);
         }
     }
 
@@ -230,10 +240,13 @@ public interface Docker extends Tree {
         UUID id;
 
         Space prefix;
+        Space execFormPrefix;
         Markers markers;
 
         Form form;
         List<DockerRightPadded<Literal>> commands;
+
+        Space execFormSuffix;
 
         @Override
         public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
@@ -247,7 +260,7 @@ public interface Docker extends Tree {
 
         @Override
         public Docker copyPaste() {
-            return new Cmd(Tree.randomId(), prefix, markers, form, commands);
+            return new Cmd(Tree.randomId(), prefix, execFormPrefix, markers, form, commands, execFormSuffix);
         }
     }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -85,6 +85,7 @@ public interface Docker extends Tree {
     class Option implements Docker {
         @EqualsAndHashCode.Include
         UUID id;
+        Space prefix;
 
         String name;
         List<KeyArgs> keyArgs;
@@ -103,7 +104,7 @@ public interface Docker extends Tree {
 
         @Override
         public Docker copyPaste() {
-            return new Option(Tree.randomId(), name, keyArgs, markers == null ? Markers.EMPTY : Markers.build(markers.getMarkers()));
+            return new Option(Tree.randomId(), prefix, name, keyArgs, markers == null ? Markers.EMPTY : Markers.build(markers.getMarkers()));
         }
     }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
@@ -451,20 +451,20 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
     public Docker visitEntrypoint(Docker.Entrypoint entrypoint, PrintOutputCapture<P> p) {
         beforeSyntax(entrypoint, p);
         p.append("ENTRYPOINT [");
-        for (int i = 0; i < entrypoint.getCommand().size(); i++) {
-            DockerRightPadded<Docker.Literal> padded = entrypoint.getCommand().get(i);
+        for (int i = 0; i < entrypoint.getCommands().size(); i++) {
+            DockerRightPadded<Docker.Literal> padded = entrypoint.getCommands().get(i);
             Docker.Literal literal = padded.getElement();
             String text = literal.getText();
             text = trimDoubleQuotes(text);
             visitSpace(literal.getPrefix(), p);
             p.append("\"").append(text).append("\"");
             visitSpace(padded.getAfter(), p);
-            if (i < entrypoint.getCommand().size() - 1) {
+            if (i < entrypoint.getCommands().size() - 1) {
                 p.append(",");
             }
         }
         p.append("]");
-        visitSpace(entrypoint.getTrailing(), p);
+        visitSpace(entrypoint.getExecFormSuffix(), p);
         afterSyntax(entrypoint, p);
         return entrypoint;
     }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Space.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Space.java
@@ -43,6 +43,16 @@ public class Space {
         return new Space(whitespace);
     }
 
+    public static Space append(Space prefix, Space suffix) {
+        if (prefix == null || prefix.isEmpty()) {
+            return suffix;
+        }
+        if (suffix == null || suffix.isEmpty()) {
+            return prefix;
+        }
+        return build(prefix.getWhitespace() + suffix.getWhitespace());
+    }
+
     public String getIndent() {
         return getWhitespaceIndent(whitespace);
     }

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserHelpers.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserHelpers.java
@@ -1,0 +1,59 @@
+package com.github.jimschubert.rewrite.docker.internal;
+
+import com.github.jimschubert.rewrite.docker.tree.Docker;
+import com.github.jimschubert.rewrite.docker.tree.DockerRightPadded;
+import com.github.jimschubert.rewrite.docker.tree.Quoting;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class DockerParserHelpers {
+
+    public static Docker.Stage assertSingleStageWithChildCount(Docker.Document document, int expectedStageCount) {
+        assertNotNull(document);
+        assertNotNull(document.getStages());
+        assertEquals(1, document.getStages().size());
+
+        Docker.Stage stage = document.getStages().get(0);
+        assertNotNull(stage.getChildren());
+        assertEquals(expectedStageCount, stage.getChildren().size());
+        return stage;
+    }
+
+    public static void assertComment(Docker.Comment comment, String expectedText, String expectedPrefix, String expectedAfter) {
+        DockerRightPadded<Docker.Literal> value = comment.getText();
+
+        assertNotNull(value.getElement());
+        assertEquals(expectedAfter, value.getAfter().getWhitespace());
+        assertEquals(expectedText, value.getElement().getText());
+        assertEquals(expectedPrefix, value.getElement().getPrefix().getWhitespace());
+    }
+
+    public static void assertDirective(Docker.Directive directive, String expectedKey, boolean hasEquals, String expectedValue, String expectedPrefix, String expectedAfter) {
+        DockerRightPadded<Docker.KeyArgs> value = directive.getDirective();
+
+        assertNotNull(value.getElement());
+        assertEquals(expectedAfter, value.getAfter().getWhitespace());
+        assertEquals(expectedKey, value.getElement().getKey());
+        assertEquals(hasEquals, value.getElement().isHasEquals());
+        assertEquals(expectedValue, value.getElement().getValue());
+        assertEquals(expectedPrefix, value.getElement().getPrefix().getWhitespace());
+    }
+
+    public static void assertArg(
+            DockerRightPadded<Docker.KeyArgs> value,
+            String expectedKey,
+            boolean hasEquals,
+            String expectedValue,
+            String expectedPrefix,
+            String expectedAfter,
+            Quoting expectedQuoting) {
+        assertNotNull(value.getElement());
+        assertEquals(expectedAfter, value.getAfter().getWhitespace());
+        assertEquals(expectedKey, value.getElement().getKey());
+        assertEquals(hasEquals, value.getElement().isHasEquals());
+        assertEquals(expectedValue, value.getElement().getValue());
+        assertEquals(expectedPrefix, value.getElement().getPrefix().getWhitespace());
+        assertEquals(expectedQuoting, value.getElement().getQuoting());
+    }
+}

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserTest.java
@@ -2,94 +2,70 @@ package com.github.jimschubert.rewrite.docker.internal;
 
 import com.github.jimschubert.rewrite.docker.tree.Docker;
 import com.github.jimschubert.rewrite.docker.tree.DockerRightPadded;
+import com.github.jimschubert.rewrite.docker.tree.Quoting;
 import com.github.jimschubert.rewrite.docker.tree.Space;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static com.github.jimschubert.rewrite.docker.internal.DockerParserHelpers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DockerParserTest {
     @Test
     void testParseSingleCommentWithTrailingSpace() {
         DockerParser parser = new DockerParser();
         Docker doc = parser.parse(new ByteArrayInputStream("# This is a comment\t\t".getBytes(StandardCharsets.UTF_8)));
-        assertNotNull(doc);
-        assertInstanceOf(Docker.Document.class, doc);
 
-        Docker.Document document = (Docker.Document) doc;
-        assertNotNull(document.getStages());
-        assertEquals(1, document.getStages().size());
-
-        Docker.Stage stage = document.getStages().get(0);
-        assertNotNull(stage.getChildren());
-        assertEquals(1, stage.getChildren().size());
+        Docker.Stage stage = assertSingleStageWithChildCount((Docker.Document) doc, 1);
 
         Docker.Comment comment = (Docker.Comment) stage.getChildren().get(0);
-        DockerRightPadded<Docker.Literal> value = comment.getText();
-
-        assertNotNull(value.getElement());
-        assertEquals("\t\t", value.getAfter().getWhitespace());
-
-        assertEquals("This is a comment", value.getElement().getText());
-        assertEquals(" ", value.getElement().getPrefix().getWhitespace());
+        assertComment(comment, "This is a comment", " ", "\t\t");
     }
-
 
     @Test
     void testParseDirective() {
         DockerParser parser = new DockerParser();
         Docker doc = parser.parse(new ByteArrayInputStream("#    syntax=docker/dockerfile:1".getBytes(StandardCharsets.UTF_8)));
-        assertNotNull(doc);
-        assertInstanceOf(Docker.Document.class, doc);
 
-        Docker.Document document = (Docker.Document) doc;
-        assertNotNull(document.getStages());
-        assertEquals(1, document.getStages().size());
-
-        Docker.Stage stage = document.getStages().get(0);
-        assertNotNull(stage.getChildren());
-        assertEquals(1, stage.getChildren().size());
+        Docker.Stage stage = assertSingleStageWithChildCount((Docker.Document) doc, 1);
 
         Docker.Directive directive = (Docker.Directive) stage.getChildren().get(0);
-        DockerRightPadded<Docker.KeyArgs> value = directive.getDirective();
-
-        assertNotNull(value.getElement());
-        assertEquals("", value.getAfter().getWhitespace());
-
-        assertEquals("syntax", value.getElement().getKey());
-        assertTrue(value.getElement().isHasEquals());
-        assertEquals("docker/dockerfile:1", value.getElement().getValue());
-
-        assertEquals("    ", value.getElement().getPrefix().getWhitespace());
+        assertDirective(directive, "syntax", true, "docker/dockerfile:1", "    ", "");
     }
 
     @Test
     void testArgDirectiveNoAssignment() {
         DockerParser parser = new DockerParser();
         Docker doc = parser.parse(new ByteArrayInputStream("ARG foo".getBytes(StandardCharsets.UTF_8)));
-        assertNotNull(doc);
-        assertInstanceOf(Docker.Document.class, doc);
 
-        Docker.Document document = (Docker.Document) doc;
-        assertNotNull(document.getStages());
-        assertEquals(1, document.getStages().size());
-
-        Docker.Stage stage = document.getStages().get(0);
-        assertNotNull(stage.getChildren());
-        assertEquals(1, stage.getChildren().size());
+        Docker.Stage stage = assertSingleStageWithChildCount((Docker.Document) doc, 1);
 
         Docker.Arg arg = (Docker.Arg) stage.getChildren().get(0);
-        DockerRightPadded<Docker.KeyArgs> value = arg.getArgs().get(0);
+        assertEquals(Space.EMPTY, arg.getPrefix());
+        List<DockerRightPadded<Docker.KeyArgs>> args = arg.getArgs();
 
-        assertNotNull(value.getElement());
-        assertEquals("", value.getAfter().getWhitespace());
+        assertArg(args.get(0), "foo", false, null, " ", "", Quoting.UNQUOTED);
+    }
 
-        assertEquals("foo", value.getElement().getKey());
-        assertFalse(value.getElement().isHasEquals());
-        assertNull(value.getElement().getValue());
+    @Test
+    void testComplexArg() {
+        DockerParser parser = new DockerParser();
+        Docker doc = parser.parse(new ByteArrayInputStream("ARG foo=bar baz MY_VAR OTHER_VAR=\"some default\" \t".getBytes(StandardCharsets.UTF_8)));
 
-        assertEquals(" ", value.getElement().getPrefix().getWhitespace());
+        Docker.Stage stage = assertSingleStageWithChildCount((Docker.Document) doc, 1);
+
+        Docker.Arg arg = (Docker.Arg) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, arg.getPrefix());
+
+        List<DockerRightPadded<Docker.KeyArgs>> args = arg.getArgs();
+        assertEquals(4, args.size());
+
+        assertArg(args.get(0), "foo", true, "bar", " ", "", Quoting.UNQUOTED);
+        assertArg(args.get(1), "baz", false, null, " ", "", Quoting.UNQUOTED);
+        assertArg(args.get(2), "MY_VAR", false, null, " ", "", Quoting.UNQUOTED);
+        assertArg(args.get(3), "OTHER_VAR", true, "some default", " ", " \t", Quoting.DOUBLE_QUOTED);
     }
 }

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserTest.java
@@ -139,4 +139,57 @@ class DockerParserTest {
         assertEquals(" ", args.get(2).getElement().getPrefix().getWhitespace());
         assertEquals("   ", args.get(2).getAfter().getWhitespace());
     }
+
+    @Test
+    void testEntrypointComplexExecForm(){
+        DockerParser parser = new DockerParser();
+        Docker doc = parser.parse(new ByteArrayInputStream("ENTRYPOINT [ \"echo\", \"Hello World\" ]   ".getBytes(StandardCharsets.UTF_8)));
+
+        Docker.Stage stage = assertSingleStageWithChildCount((Docker.Document) doc, 1);
+
+        Docker.Entrypoint entrypoint = (Docker.Entrypoint) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, entrypoint.getPrefix());
+
+        List<DockerRightPadded<Docker.Literal>> args = entrypoint.getCommands();
+        assertEquals(2, args.size());
+
+        assertEquals("echo", args.get(0).getElement().getText());
+        assertEquals(" ", args.get(0).getElement().getPrefix().getWhitespace());
+        assertEquals("Hello World", args.get(1).getElement().getText());
+        assertEquals(" ", args.get(1).getElement().getPrefix().getWhitespace());
+        assertEquals(" ", args.get(1).getElement().getTrailing().getWhitespace());
+        assertEquals("   ", entrypoint.getExecFormSuffix().getWhitespace());
+    }
+
+    @Test
+    void testEntrypointShellForm() {
+        DockerParser parser = new DockerParser();
+        Docker doc = parser.parse(new ByteArrayInputStream("ENTRYPOINT echo Hello World   ".getBytes(StandardCharsets.UTF_8)));
+        Docker.Stage stage = assertSingleStageWithChildCount((Docker.Document) doc, 1);
+        Docker.Entrypoint entrypoint = (Docker.Entrypoint) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, entrypoint.getPrefix());
+        List<DockerRightPadded<Docker.Literal>> args = entrypoint.getCommands();
+        assertEquals(3, args.size());
+        assertEquals("echo", args.get(0).getElement().getText());
+        assertEquals("Hello", args.get(1).getElement().getText());
+        assertEquals("World", args.get(2).getElement().getText());
+        assertEquals(" ", args.get(0).getElement().getPrefix().getWhitespace());
+        assertEquals(" ", args.get(1).getElement().getPrefix().getWhitespace());
+        assertEquals(" ", args.get(2).getElement().getPrefix().getWhitespace());
+        assertEquals("   ", args.get(2).getAfter().getWhitespace());
+    }
+
+    @Test
+    void testEntrypointShellFormWithQuotes() {
+        DockerParser parser = new DockerParser();
+        Docker doc = parser.parse(new ByteArrayInputStream("ENTRYPOINT \"echo Hello World\"   ".getBytes(StandardCharsets.UTF_8)));
+        Docker.Stage stage = assertSingleStageWithChildCount((Docker.Document) doc, 1);
+        Docker.Entrypoint entrypoint = (Docker.Entrypoint) stage.getChildren().get(0);
+        assertEquals(Space.EMPTY, entrypoint.getPrefix());
+        List<DockerRightPadded<Docker.Literal>> args = entrypoint.getCommands();
+        assertEquals(1, args.size());
+        assertEquals("echo Hello World", args.get(0).getElement().getText());
+        assertEquals(" ", args.get(0).getElement().getPrefix().getWhitespace());
+        assertEquals("   ", args.get(0).getAfter().getWhitespace());
+    }
 }

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserTest.java
@@ -1,0 +1,95 @@
+package com.github.jimschubert.rewrite.docker.internal;
+
+import com.github.jimschubert.rewrite.docker.tree.Docker;
+import com.github.jimschubert.rewrite.docker.tree.DockerRightPadded;
+import com.github.jimschubert.rewrite.docker.tree.Space;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DockerParserTest {
+    @Test
+    void testParseSingleCommentWithTrailingSpace() {
+        DockerParser parser = new DockerParser();
+        Docker doc = parser.parse(new ByteArrayInputStream("# This is a comment\t\t".getBytes(StandardCharsets.UTF_8)));
+        assertNotNull(doc);
+        assertInstanceOf(Docker.Document.class, doc);
+
+        Docker.Document document = (Docker.Document) doc;
+        assertNotNull(document.getStages());
+        assertEquals(1, document.getStages().size());
+
+        Docker.Stage stage = document.getStages().get(0);
+        assertNotNull(stage.getChildren());
+        assertEquals(1, stage.getChildren().size());
+
+        Docker.Comment comment = (Docker.Comment) stage.getChildren().get(0);
+        DockerRightPadded<Docker.Literal> value = comment.getText();
+
+        assertNotNull(value.getElement());
+        assertEquals("\t\t", value.getAfter().getWhitespace());
+
+        assertEquals("This is a comment", value.getElement().getText());
+        assertEquals(" ", value.getElement().getPrefix().getWhitespace());
+    }
+
+
+    @Test
+    void testParseDirective() {
+        DockerParser parser = new DockerParser();
+        Docker doc = parser.parse(new ByteArrayInputStream("#    syntax=docker/dockerfile:1".getBytes(StandardCharsets.UTF_8)));
+        assertNotNull(doc);
+        assertInstanceOf(Docker.Document.class, doc);
+
+        Docker.Document document = (Docker.Document) doc;
+        assertNotNull(document.getStages());
+        assertEquals(1, document.getStages().size());
+
+        Docker.Stage stage = document.getStages().get(0);
+        assertNotNull(stage.getChildren());
+        assertEquals(1, stage.getChildren().size());
+
+        Docker.Directive directive = (Docker.Directive) stage.getChildren().get(0);
+        DockerRightPadded<Docker.KeyArgs> value = directive.getDirective();
+
+        assertNotNull(value.getElement());
+        assertEquals("", value.getAfter().getWhitespace());
+
+        assertEquals("syntax", value.getElement().getKey());
+        assertTrue(value.getElement().isHasEquals());
+        assertEquals("docker/dockerfile:1", value.getElement().getValue());
+
+        assertEquals("    ", value.getElement().getPrefix().getWhitespace());
+    }
+
+    @Test
+    void testArgDirectiveNoAssignment() {
+        DockerParser parser = new DockerParser();
+        Docker doc = parser.parse(new ByteArrayInputStream("ARG foo".getBytes(StandardCharsets.UTF_8)));
+        assertNotNull(doc);
+        assertInstanceOf(Docker.Document.class, doc);
+
+        Docker.Document document = (Docker.Document) doc;
+        assertNotNull(document.getStages());
+        assertEquals(1, document.getStages().size());
+
+        Docker.Stage stage = document.getStages().get(0);
+        assertNotNull(stage.getChildren());
+        assertEquals(1, stage.getChildren().size());
+
+        Docker.Arg arg = (Docker.Arg) stage.getChildren().get(0);
+        DockerRightPadded<Docker.KeyArgs> value = arg.getArgs().get(0);
+
+        assertNotNull(value.getElement());
+        assertEquals("", value.getAfter().getWhitespace());
+
+        assertEquals("foo", value.getElement().getKey());
+        assertFalse(value.getElement().isHasEquals());
+        assertNull(value.getElement().getValue());
+
+        assertEquals(" ", value.getElement().getPrefix().getWhitespace());
+    }
+}


### PR DESCRIPTION
This is a redo of the parser implementation I implemented in https://github.com/jimschubert/docker-parser/, but directly parsing into the rewrite LST.

This will probably change a bit about the LST types as I attempt to make them more usable. For example, I'll eventually move all markers fields to last, and make the types in the form `prefix <content> trailing markers` for consistency.

The parseElements function is a bit hairy to support unquoted multi-line and quoted multi-line literal text. Docker describes the exec format as a JSON array syntax, but I parse it differently so I can handle quoting and instantiation into KeyArgs, Ports, etc. It might be overly complicated at the moment but I can revisit it later once everything is tested.