### PR TITLE
Remove DockerRightPadding for literals and options

### DIFF
--- a/src/main/java/com/github/jimschubert/rewrite/docker/ChangeImage.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/ChangeImage.java
@@ -108,18 +108,18 @@ public class ChangeImage extends Recipe {
                     if (newPlatform != null) {
                         platform = newPlatform;
                     } else {
-                        platform = from.getPlatform().getElement().getText();
+                        platform = from.getPlatform().getText();
                     }
 
-                    if (image != null && !image.equals(from.getImage().getElement().getText())) {
+                    if (image != null && !image.equals(from.getImage().getText())) {
                         from = from.image(image);
                     }
 
-                    if (version != null && !version.equals(from.getVersion().getElement().getText())) {
+                    if (version != null && !version.equals(from.getVersion().getText())) {
                         from = from.version(version);
                     }
 
-                    if (platform != null && !platform.equals(from.getPlatform().getElement().getText())) {
+                    if (platform != null && !platform.equals(from.getPlatform().getText())) {
                         from = from.platform(platform);
                     }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
@@ -118,8 +118,8 @@ public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
         return add
                 .withPrefix(visitSpace(add.getPrefix(), p))
                 .withOptions(ListUtils.map(add.getOptions(), o -> visitDockerRightPadded(o, p)))
-                .withSources(ListUtils.map(add.getSources(), s -> visitDockerRightPadded(s, p)))
-                .withDestination(visitDockerRightPadded(add.getDestination(), p))
+                .withSources(ListUtils.map(add.getSources(), s -> visitAndCast(s, p)))
+                .withDestination(visitAndCast(add.getDestination(), p))
                 .withMarkers(visitMarkers(add.getMarkers(), p));
     }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
@@ -70,8 +70,8 @@ public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
     public Docker visitRun(Docker.Run run, P p) {
         return run
                 .withPrefix(visitSpace(run.getPrefix(), p))
-                .withOptions(ListUtils.map(run.getOptions(), o -> visitDockerRightPadded(o, p)))
-                .withCommands(ListUtils.map(run.getCommands(), c -> visitDockerRightPadded(c, p)))
+                .withOptions(ListUtils.map(run.getOptions(), o -> visitAndCast(o, p)))
+                .withCommands(ListUtils.map(run.getCommands(), c -> visitAndCast(c, p)))
                 .withMarkers(visitMarkers(run.getMarkers(), p));
     }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
@@ -117,7 +117,7 @@ public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
     public Docker visitAdd(Docker.Add add, P p) {
         return add
                 .withPrefix(visitSpace(add.getPrefix(), p))
-                .withOptions(ListUtils.map(add.getOptions(), o -> visitDockerRightPadded(o, p)))
+                .withOptions(ListUtils.map(add.getOptions(), o -> visitAndCast(o, p)))
                 .withSources(ListUtils.map(add.getSources(), s -> visitAndCast(s, p)))
                 .withDestination(visitAndCast(add.getDestination(), p))
                 .withMarkers(visitMarkers(add.getMarkers(), p));
@@ -126,9 +126,9 @@ public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
     public Docker visitCopy(Docker.Copy copy, P p) {
         return copy
                 .withPrefix(visitSpace(copy.getPrefix(), p))
-                .withOptions(ListUtils.map(copy.getOptions(), o -> visitDockerRightPadded(o, p)))
-                .withSources(ListUtils.map(copy.getSources(), s -> visitDockerRightPadded(s, p)))
-                .withDestination(visitDockerRightPadded(copy.getDestination(), p))
+                .withOptions(ListUtils.map(copy.getOptions(), o -> visitAndCast(o, p)))
+                .withSources(ListUtils.map(copy.getSources(), s -> visitAndCast(s, p)))
+                .withDestination(visitAndCast(copy.getDestination(), p))
                 .withMarkers(visitMarkers(copy.getMarkers(), p));
     }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
@@ -202,7 +202,7 @@ public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
         return shell
                 .withPrefix(visitSpace(shell.getPrefix(), p))
                 .withExecFormPrefix(visitSpace(shell.getExecFormPrefix(), p))
-                .withCommands(ListUtils.map(shell.getCommands(), c -> visitDockerRightPadded(c, p)))
+                .withCommands(ListUtils.map(shell.getCommands(), c -> visitAndCast(c, p)))
                 .withExecFormSuffix(visitSpace(shell.getExecFormSuffix(), p))
                 .withMarkers(visitMarkers(shell.getMarkers(), p));
     }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
@@ -147,7 +147,7 @@ public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
                 .withForm(volume.getForm())
                 .withPrefix(visitSpace(volume.getPrefix(), p))
                 .withExecFormPrefix(visitSpace(volume.getExecFormPrefix(), p))
-                .withPaths(ListUtils.map(volume.getPaths(), path -> visitDockerRightPadded(path, p)))
+                .withPaths(ListUtils.map(volume.getPaths(), path -> visitAndCast(path, p)))
                 .withExecFormSuffix(visitSpace(volume.getExecFormSuffix(), p))
                 .withMarkers(visitMarkers(volume.getMarkers(), p));
     }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
@@ -53,11 +53,11 @@ public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
 
     public Docker visitFrom(Docker.From from, P p) {
         return from.withPrefix(visitSpace(from.getPrefix(), p))
-                .withImage(visitDockerRightPadded(from.getImage(), p))
-                .withPlatform(visitDockerRightPadded(from.getPlatform(), p))
-                .withVersion(visitDockerRightPadded(from.getVersion(), p))
+                .withImage(visitAndCast(from.getImage(), p))
+                .withPlatform(visitAndCast(from.getPlatform(), p))
+                .withVersion(visitAndCast(from.getVersion(), p))
                 .withAs(visitAndCast(from.getAs(), p))
-                .withAlias(visitDockerRightPadded(from.getAlias(), p))
+                .withAlias(visitAndCast(from.getAlias(), p))
                 .withMarkers(visitMarkers(from.getMarkers(), p));
     }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
@@ -194,7 +194,7 @@ public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
                 .withPrefix(visitSpace(healthcheck.getPrefix(), p))
                 .withType(healthcheck.getType())
                 .withOptions(ListUtils.map(healthcheck.getOptions(), o -> visitDockerRightPadded(o, p)))
-                .withCommands(ListUtils.map(healthcheck.getCommands(), c -> visitDockerRightPadded(c, p)))
+                .withCommands(ListUtils.map(healthcheck.getCommands(), c -> visitAndCast(c, p)))
                 .withMarkers(visitMarkers(healthcheck.getMarkers(), p));
     }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
@@ -137,7 +137,7 @@ public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
                 .withForm(entrypoint.getForm())
                 .withPrefix(visitSpace(entrypoint.getPrefix(), p))
                 .withExecFormPrefix(visitSpace(entrypoint.getExecFormPrefix(), p))
-                .withCommands(ListUtils.map(entrypoint.getCommands(), c -> visitDockerRightPadded(c, p)))
+                .withCommands(ListUtils.map(entrypoint.getCommands(), c -> visitAndCast(c, p)))
                 .withExecFormSuffix(visitSpace(entrypoint.getExecFormSuffix(), p))
                 .withMarkers(visitMarkers(entrypoint.getMarkers(), p));
     }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/DockerVisitor.java
@@ -80,7 +80,7 @@ public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
                 .withForm(cmd.getForm())
                 .withPrefix(visitSpace(cmd.getPrefix(), p))
                 .withExecFormPrefix(visitSpace(cmd.getExecFormPrefix(), p))
-                .withCommands(ListUtils.map(cmd.getCommands(), c -> visitDockerRightPadded(c, p)))
+                .withCommands(ListUtils.map(cmd.getCommands(), c -> visitAndCast(c, p)))
                 .withExecFormSuffix(visitSpace(cmd.getExecFormSuffix(), p))
                 .withMarkers(visitMarkers(cmd.getMarkers(), p));
     }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/NameAllStages.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/NameAllStages.java
@@ -74,19 +74,19 @@ public class NameAllStages extends Recipe {
             public Docker.Copy visitCopy(Docker.Copy copy, ExecutionContext executionContext) {
                 if (copy.getOptions() != null && copy.getOptions().stream().anyMatch(
                         o -> {
-                            Docker.KeyArgs key = o.getElement().getKeyArgs();
+                            Docker.KeyArgs key = o.getKeyArgs();
                             return (key != null && "--from".equals(key.key())) && (key.value() != null && key.value().matches("^\\d+$"));
                         })) {
                     return copy.withOptions(
                             ListUtils.map(copy.getOptions(), o -> {
-                                if (o == null || o.getElement() == null) {
+                                if (o == null) {
                                     return o;
                                 }
 
-                                Docker.KeyArgs key = o.getElement().getKeyArgs();
+                                Docker.KeyArgs key = o.getKeyArgs();
                                 if (key != null && "--from".equals(key.key()) && (key.value() != null && key.value().matches("^\\d+$"))) {
                                     int index = Integer.parseInt(key.value());
-                                    return o.map(e -> e.withKeyArgs(key.withValue(key.getValue().withText("stage" + index))));
+                                    return o.withKeyArgs(key.withValue(key.getValue().withText("stage" + index)));
                                 }
 
                                 return o;

--- a/src/main/java/com/github/jimschubert/rewrite/docker/NameAllStages.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/NameAllStages.java
@@ -62,7 +62,7 @@ public class NameAllStages extends Recipe {
                 Docker.Stage stage = Objects.requireNonNull(getCursor().getParent()).firstEnclosing(Docker.Stage.class);
                 if (stage != null && stage.getMarkers() != null && stage.getMarkers().findFirst(Counter.class).isPresent()) {
                     Counter counter = stage.getMarkers().findFirst(Counter.class).get();
-                    if (!counter.isLast && (from.getAlias().getElement().getText() == null || from.getAlias().getElement().getText().isEmpty())) {
+                    if (!counter.isLast && (from.getAlias().getText() == null || from.getAlias().getText().isEmpty())) {
                         return from.alias("stage" + counter.index);
                     }
                 }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/analysis/ListImages.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/analysis/ListImages.java
@@ -63,8 +63,8 @@ public class ListImages extends ScanningRecipe<List<ImageUseReport.Row>> {
                                 if (child instanceof Docker.From) {
                                     Docker.From from = (Docker.From) child;
                                     String platformSwitch = null;
-                                    if (from.getPlatform().getElement() != null && from.getPlatform().getElement().getText() != null) {
-                                        platformSwitch = from.getPlatform().getElement().getText().split("=")[1];
+                                    if (from.getPlatform().getText() != null) {
+                                        platformSwitch = from.getPlatform().getText().split("=")[1];
                                     }
 
                                     acc.add(new ImageUseReport.Row(
@@ -73,7 +73,7 @@ public class ListImages extends ScanningRecipe<List<ImageUseReport.Row>> {
                                             from.getTag(),
                                             from.getDigest(),
                                             platformSwitch,
-                                            from.getAlias().getElement().getText()
+                                            from.getAlias().getText()
                                     ));
                                 }
                             }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/analysis/ListRemoteFiles.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/analysis/ListRemoteFiles.java
@@ -61,15 +61,15 @@ public class ListRemoteFiles extends ScanningRecipe<List<RemoteFileReport.Row>> 
                             for (Docker child : stage.getChildren()) {
                                 if (child instanceof Docker.Add) {
                                     Docker.Add instruction = (Docker.Add) child;
-                                    List<DockerRightPadded<Docker.Literal>> urls = instruction.getSources().stream()
-                                            .filter(s -> s.getElement().getText().startsWith("http"))
-                                            .collect(Collectors.toCollection(ArrayList::new));
+                                    List<Docker.Literal> urls = instruction.getSources().stream()
+                                            .filter(s -> s.getText().startsWith("http"))
+                                            .collect(Collectors.toList());
 
                                     if (!urls.isEmpty()) {
                                         urls.forEach(url -> {
                                             acc.add(new RemoteFileReport.Row(
                                                     dockerfile.getSourcePath().toString(),
-                                                    url.getElement().getText()
+                                                    url.getText()
                                             ));
                                         });
                                     }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/analysis/ListRemoteFiles.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/analysis/ListRemoteFiles.java
@@ -17,7 +17,6 @@ package com.github.jimschubert.rewrite.docker.analysis;
 import com.github.jimschubert.rewrite.docker.DockerIsoVisitor;
 import com.github.jimschubert.rewrite.docker.table.RemoteFileReport;
 import com.github.jimschubert.rewrite.docker.tree.Docker;
-import com.github.jimschubert.rewrite.docker.tree.DockerRightPadded;
 import lombok.EqualsAndHashCode;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.ScanningRecipe;

--- a/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
@@ -408,9 +408,14 @@ public class DockerfileParser {
                 return new Docker.Cmd(Tree.randomId(), form, state.prefix(), execFormPrefix,
                         parseLiterals(form, content).stream()
                                 .map(d -> d.getElement().withTrailing(Space.append(d.getElement().getTrailing(), d.getAfter())))
-                                .collect(Collectors.toList()), execFormSuffix, Markers.EMPTY, Space.EMPTY);
+                                .collect(Collectors.toList()),
+                        execFormSuffix, Markers.EMPTY, Space.EMPTY);
             } else if (name.equals(Docker.Shell.class.getSimpleName())) {
-                return new Docker.Shell(Tree.randomId(), state.prefix(), execFormPrefix, parseLiterals(form, content), execFormSuffix, Markers.EMPTY, Space.EMPTY);
+                return new Docker.Shell(Tree.randomId(), state.prefix(), execFormPrefix,
+                        parseLiterals(form, content).stream()
+                                .map(d -> d.getElement().withTrailing(Space.append(d.getElement().getTrailing(), d.getAfter())))
+                                .collect(Collectors.toList()),
+                        execFormSuffix, Markers.EMPTY, Space.EMPTY);
             } else if (name.equals(Docker.Volume.class.getSimpleName())) {
                 return new Docker.Volume(Tree.randomId(), form, state.prefix(), execFormPrefix, parseLiterals(form, content), execFormSuffix, Markers.EMPTY, Space.EMPTY);
             } else if (name.equals(Docker.Workdir.class.getSimpleName())) {

--- a/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
@@ -424,11 +424,11 @@ public class DockerfileParser {
 
         private Docker.@NotNull Comment parseComment() {
             StringWithPadding stringWithPadding = StringWithPadding.of(instruction.toString());
-
+            Docker.Literal commentLiteral = createLiteral(stringWithPadding.content()).withPrefix(stringWithPadding.prefix());
             return new Docker.Comment(
                     Tree.randomId(),
                     state.prefix(),
-                    DockerRightPadded.build(createLiteral(stringWithPadding.content()).withPrefix(stringWithPadding.prefix())).withAfter(state.rightPadding()),
+                    commentLiteral.withTrailing(Space.append(commentLiteral.getTrailing(), state.rightPadding())),
                     Markers.EMPTY,
                     Space.EMPTY
             );

--- a/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
@@ -419,7 +419,10 @@ public class DockerfileParser {
                 return new Docker.Workdir(Tree.randomId(), state.prefix(), lit.isEmpty() ? null : lit.get(0).getElement(), Markers.EMPTY, Space.EMPTY);
             }
 
-            return new Docker.Entrypoint(Tree.randomId(), form, state.prefix(), execFormPrefix, parseLiterals(form, content), execFormSuffix, Markers.EMPTY, Space.EMPTY);
+            return new Docker.Entrypoint(Tree.randomId(), form, state.prefix(), execFormPrefix,
+                    parseLiterals(form, content).stream()
+                            .map(d -> d.getElement().withTrailing(Space.append(d.getElement().getTrailing(), d.getAfter())))
+                            .collect(Collectors.toList()), execFormSuffix, Markers.EMPTY, Space.EMPTY);
         }
 
         private Docker.@NotNull Comment parseComment() {

--- a/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
@@ -417,7 +417,11 @@ public class DockerfileParser {
                                 .collect(Collectors.toList()),
                         execFormSuffix, Markers.EMPTY, Space.EMPTY);
             } else if (name.equals(Docker.Volume.class.getSimpleName())) {
-                return new Docker.Volume(Tree.randomId(), form, state.prefix(), execFormPrefix, parseLiterals(form, content), execFormSuffix, Markers.EMPTY, Space.EMPTY);
+                return new Docker.Volume(Tree.randomId(), form, state.prefix(), execFormPrefix,
+                        parseLiterals(form, content).stream()
+                                .map(d -> d.getElement().withTrailing(Space.append(d.getElement().getTrailing(), d.getAfter())))
+                                .collect(Collectors.toList()),
+                        execFormSuffix, Markers.EMPTY, Space.EMPTY);
             } else if (name.equals(Docker.Workdir.class.getSimpleName())) {
                 List<DockerRightPadded<Docker.Literal>> lit = parseLiterals(form, content);
                 return new Docker.Workdir(Tree.randomId(), state.prefix(), lit.isEmpty() ? null : lit.get(0).getElement(), Markers.EMPTY, Space.EMPTY);

--- a/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
@@ -360,12 +360,11 @@ public class DockerfileParser {
 
                 String value = literal.getElement().getText();
                 if (value.startsWith("--")) {
-                    // TODO: literal.getAfter()?
                     options.add(0, new Docker.Option(
                             Tree.randomId(),
                             literal.getElement().getPrefix(),
                             stringToKeyArgs(literal.getElement().getText()),
-                            Markers.EMPTY));
+                            Markers.EMPTY, literal.getAfter()));
                 } else {
                     sources.add(0, literal.getElement().withTrailing(Space.append(literal.getElement().getTrailing(), literal.getAfter())));
                 }
@@ -597,21 +596,21 @@ public class DockerfileParser {
         private Docker.@NotNull Run parseRun() {
             // TODO: Run allows for JSON array syntax (exec form)
             List<DockerRightPadded<Docker.Literal>> literals = parseLiterals(instruction.toString());
-            List<DockerRightPadded<Docker.Option>> options = new ArrayList<>();
-            List<DockerRightPadded<Docker.Literal>> commands = new ArrayList<>();
+            List<Docker.Option> options = new ArrayList<>();
+            List<Docker.Literal> commands = new ArrayList<>();
 
             boolean doneWithOptions = false;
             for (DockerRightPadded<Docker.Literal> literal : literals) {
                 String value = literal.getElement().getText();
                 if (!doneWithOptions && (value.startsWith("--mount") || value.startsWith("--network") || value.startsWith("--security"))) {
-                    options.add(DockerRightPadded.build(new Docker.Option(
+                    options.add(new Docker.Option(
                             Tree.randomId(),
                             literal.getElement().getPrefix(),
                             stringToKeyArgs(literal.getElement().getText()),
-                            Markers.EMPTY)).withAfter(literal.getAfter()));
+                            Markers.EMPTY, literal.getAfter()));
                 } else {
                     doneWithOptions = true;
-                    commands.add(literal);
+                    commands.add(literal.getElement().withTrailing(Space.append(literal.getElement().getTrailing(), literal.getAfter())));
                 }
             }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.github.jimschubert.rewrite.docker.internal.ParserConstants.*;
 import static com.github.jimschubert.rewrite.docker.internal.ParserUtils.stringToKeyArgs;
@@ -370,7 +371,13 @@ public class DockerfileParser {
             }
 
             if (name.equals(Docker.Add.class.getSimpleName())) {
-                return new Docker.Add(Tree.randomId(), state.prefix(), options, sources, destination, Markers.EMPTY, Space.EMPTY);
+                return new Docker.Add(Tree.randomId(), state.prefix(), options,
+                        sources.stream().map(l -> {
+                            Docker.Literal lit = l.getElement();
+                            return lit.withTrailing(Space.append(lit.getTrailing(), l.getAfter()));
+                        }).collect(Collectors.toList()),
+                        destination == null ? null : destination.getElement().withTrailing(Space.append(destination.getElement().getTrailing(), destination.getAfter())),
+                        Markers.EMPTY, Space.EMPTY);
             }
 
             return new Docker.Copy(Tree.randomId(), state.prefix(), options, sources, destination, Markers.EMPTY, Space.EMPTY);

--- a/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParser.java
@@ -406,7 +406,10 @@ public class DockerfileParser {
             }
 
             if (name.equals(Docker.Cmd.class.getSimpleName())) {
-                return new Docker.Cmd(Tree.randomId(), form, state.prefix(), execFormPrefix, parseLiterals(form, content), execFormSuffix, Markers.EMPTY, Space.EMPTY);
+                return new Docker.Cmd(Tree.randomId(), form, state.prefix(), execFormPrefix,
+                        parseLiterals(form, content).stream()
+                                .map(d -> d.getElement().withTrailing(Space.append(d.getElement().getTrailing(), d.getAfter())))
+                                .collect(Collectors.toList()), execFormSuffix, Markers.EMPTY, Space.EMPTY);
             } else if (name.equals(Docker.Shell.class.getSimpleName())) {
                 return new Docker.Shell(Tree.randomId(), state.prefix(), execFormPrefix, parseLiterals(form, content), execFormSuffix, Markers.EMPTY, Space.EMPTY);
             } else if (name.equals(Docker.Volume.class.getSimpleName())) {

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -1049,7 +1049,7 @@ public interface Docker extends Tree {
         Space prefix;
 
         Space execFormPrefix;
-        List<DockerRightPadded<Literal>> commands;
+        List<Literal> commands;
         Space execFormSuffix;
         Markers markers;
         Space eol;
@@ -1075,7 +1075,6 @@ public interface Docker extends Tree {
                     Space.build(" "),
                     Arrays.stream(commands)
                             .map(Literal::build)
-                            .map(DockerRightPadded::build)
                             .collect(Collectors.toList()),
                     Space.EMPTY,
                     Markers.EMPTY,

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -274,8 +274,8 @@ public interface Docker extends Tree {
 
         List<DockerRightPadded<Option>> options;
 
-        List<DockerRightPadded<Literal>> sources;
-        DockerRightPadded<Literal> destination;
+        List<Literal> sources;
+        Literal destination;
 
         Markers markers;
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -840,7 +840,7 @@ public interface Docker extends Tree {
         Type type;
 
         List<DockerRightPadded<KeyArgs>> options;
-        List<DockerRightPadded<Literal>> commands;
+        List<Literal> commands;
 
         Markers markers;
 
@@ -861,8 +861,8 @@ public interface Docker extends Tree {
             return new Healthcheck(Tree.randomId(),
                     prefix,
                     type,
-                    options == null ? new ArrayList<>() : new ArrayList<>(options),
-                    commands == null ? new ArrayList<>() : new ArrayList<>(commands),
+                    options,
+                    commands,
                     markers,
                     eol);
         }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -272,7 +272,7 @@ public interface Docker extends Tree {
 
         Space prefix;
 
-        List<DockerRightPadded<Option>> options;
+        List<Option> options;
 
         List<Literal> sources;
         Literal destination;
@@ -440,9 +440,9 @@ public interface Docker extends Tree {
 
         Space prefix;
 
-        List<DockerRightPadded<Option>> options;
-        List<DockerRightPadded<Literal>> sources;
-        DockerRightPadded<Literal> destination;
+        List<Option> options;
+        List<Literal> sources;
+        Literal destination;
 
         Markers markers;
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -542,7 +542,7 @@ public interface Docker extends Tree {
         Form form;
         Space prefix;
         Space execFormPrefix;
-        List<DockerRightPadded<Literal>> commands;
+        List<Literal> commands;
         Space execFormSuffix;
         Markers markers;
         Space eol;
@@ -577,8 +577,7 @@ public interface Docker extends Tree {
                                     .withPrefix(form == Form.EXEC ? Space.EMPTY : Space.build(" "))
                                     .withTrailing(Space.EMPTY)
                             )
-                            .map(DockerRightPadded::build)
-                            .collect(Collectors.toCollection(ArrayList::new)),
+                            .collect(Collectors.toList()),
                     Space.EMPTY,
                     Markers.EMPTY,
                     Space.build("\n"));

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -400,7 +400,7 @@ public interface Docker extends Tree {
 
         Space prefix;
 
-        DockerRightPadded<Literal> text;
+        Literal text;
 
         Markers markers;
 
@@ -424,7 +424,7 @@ public interface Docker extends Tree {
         public static Comment build(String text) {
             return new Comment(Tree.randomId(),
                     Space.EMPTY,
-                    DockerRightPadded.build(Literal.build(text).withPrefix(Space.build(" "))),
+                    Literal.build(text).withPrefix(Space.build(" ")),
                     Markers.EMPTY,
                     Space.build("\n"));
         }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -164,6 +164,8 @@ public interface Docker extends Tree {
 
         Markers markers;
 
+        Space trailing;
+
         @Override
         public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {
             return v.visitOption(this, p);
@@ -176,11 +178,11 @@ public interface Docker extends Tree {
 
         @Override
         public Docker copyPaste() {
-            return new Option(Tree.randomId(), prefix, keyArgs, markers == null ? Markers.EMPTY : Markers.build(markers.getMarkers()));
+            return new Option(Tree.randomId(), prefix, keyArgs, markers == null ? Markers.EMPTY : Markers.build(markers.getMarkers()), trailing);
         }
 
         public static Option build(String key, String value) {
-            return new Option(Tree.randomId(), Space.EMPTY, KeyArgs.build(key, value).withHasEquals(true), Markers.EMPTY);
+            return new Option(Tree.randomId(), Space.EMPTY, KeyArgs.build(key, value).withHasEquals(true), Markers.EMPTY, Space.EMPTY);
         }
     }
 
@@ -1003,8 +1005,8 @@ public interface Docker extends Tree {
 
         Space prefix;
 
-        List<DockerRightPadded<Option>> options;
-        List<DockerRightPadded<Literal>> commands;
+        List<Option> options;
+        List<Literal> commands;
 
         Markers markers;
         Space eol;
@@ -1030,7 +1032,6 @@ public interface Docker extends Tree {
                     null,
                     Arrays.stream(commands)
                             .map(s -> Literal.build(s).withPrefix(Space.build(" ")))
-                            .map(DockerRightPadded::build)
                             .collect(Collectors.toList()),
                     Markers.EMPTY,
                     Space.build("\n"));

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -710,11 +710,11 @@ public interface Docker extends Tree {
         UUID id;
 
         Space prefix;
-        DockerRightPadded<Literal> platform;
-        DockerRightPadded<Literal> image;
-        DockerRightPadded<Literal> version;
+        Literal platform;
+        Literal image;
+        Literal version;
         Literal as;
-        DockerRightPadded<Literal> alias;
+        Literal alias;
         Space trailing;
         Markers markers;
         Space eol;
@@ -735,18 +735,18 @@ public interface Docker extends Tree {
         }
 
         public String getImageSpec() {
-            return image.getElement().getText();
+            return image.getText();
         }
 
         public String getImageSpecWithVersion() {
-            if (version.getElement() == null || version.getElement().getText() == null) {
-                return image.getElement().getText();
+            if (version.getText() == null) {
+                return image.getText();
             }
-            return image.getElement().getText() + version.getElement().getText();
+            return image.getText() + version.getText();
         }
 
         public String getDigest() {
-            String v = version.getElement().getText();
+            String v = version.getText();
             if (v == null) {
                 return null;
             }
@@ -754,15 +754,15 @@ public interface Docker extends Tree {
         }
 
         public From platform(String platform) {
-            return this.withPlatform(this.platform.map(p -> p.withText(platform)));
+            return this.withPlatform(this.platform.withText(platform));
         }
 
         public From image(String image) {
-            return this.withImage(this.image.map(i -> i.withText(image)));
+            return this.withImage(this.image.withText(image));
         }
 
         public From version(String version) {
-            return this.withVersion(this.version.map(v -> v.withText(version)));
+            return this.withVersion(this.version.withText(version));
         }
 
         public From withDigest(String digest) {
@@ -782,7 +782,7 @@ public interface Docker extends Tree {
         }
 
         public String getTag() {
-            String v = version.getElement().getText();
+            String v = version.getText();
             if (v == null) {
                 return null;
             }
@@ -795,16 +795,17 @@ public interface Docker extends Tree {
             if (this.as.getText() == null || this.as.getText().isBlank()) {
                 result = result.withAs(Literal.build("AS").withPrefix(this.as.getPrefix().map(p -> p == null || p.isEmpty() ? " " : p)));
             }
-            return result.withAlias(this.alias.map(a -> a.withText(alias).withPrefix(a.getPrefix().map(p -> p == null || p.isEmpty() ? " " : p))));
+            return result.withAlias(this.alias.withText(alias).withPrefix(this.alias.getPrefix().map(p -> p == null || p.isEmpty() ? " " : p)));
         }
 
         public static From build(String image) {
-            return new From(Tree.randomId(), Space.EMPTY,
-                    DockerRightPadded.build(Literal.build(null).withPrefix(Space.build(" "))),
-                    DockerRightPadded.build(Literal.build(null).withPrefix(Space.build(" "))),
-                    DockerRightPadded.build(Literal.build(null).withPrefix(Space.build(" "))),
+            return new From(Tree.randomId(),
+                    Space.EMPTY,
                     Literal.build(null).withPrefix(Space.build(" ")),
-                    DockerRightPadded.build(Literal.build(null).withPrefix(Space.build(" "))),
+                    Literal.build(null).withPrefix(Space.build(" ")),
+                    /*version*/Literal.build(null).withPrefix(Space.EMPTY).withTrailing(Space.EMPTY),
+                    Literal.build(null).withPrefix(Space.build(" ")),
+                    Literal.build(null).withPrefix(Space.build(" ")),
                     Space.EMPTY,
                     Markers.EMPTY,
                     Space.build("\n")).image(image);
@@ -812,11 +813,11 @@ public interface Docker extends Tree {
 
         public static From build(String prefix, String platform, String image, String version, String alias) {
             return new From(Tree.randomId(), Space.build(prefix),
-                    DockerRightPadded.build(Literal.build(null).withPrefix(Space.build(" "))),
-                    DockerRightPadded.build(Literal.build(null).withPrefix(Space.build(" "))),
-                    DockerRightPadded.build(Literal.build(null).withPrefix(Space.build(" "))),
+                    Literal.build(null).withPrefix(Space.build(" ")),
+                    Literal.build(null).withPrefix(Space.build(" ")),
+                    Literal.build(null).withPrefix(Space.build(" ")),
                     alias != null && !alias.isBlank() ? Literal.build("AS").withPrefix(Space.build(" ")) : null,
-                    DockerRightPadded.build(Literal.build(alias).withPrefix(Space.build(" "))),
+                    Literal.build(alias).withPrefix(Space.build(" ")),
                     Space.EMPTY,
                     Markers.EMPTY,
                     Space.build("\n")

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -351,7 +351,7 @@ public interface Docker extends Tree {
         Form form;
         Space prefix;
         Space execFormPrefix;
-        List<DockerRightPadded<Literal>> commands;
+        List<Literal> commands;
         Space execFormSuffix;
         Markers markers;
         Space eol;
@@ -384,8 +384,7 @@ public interface Docker extends Tree {
                                     .withPrefix(form == Form.EXEC ? Space.EMPTY : Space.build(" "))
                                     .withTrailing(Space.EMPTY)
                             )
-                            .map(DockerRightPadded::build)
-                            .collect(Collectors.toCollection(ArrayList::new)),
+                            .collect(Collectors.toList()),
                     Space.EMPTY,
                     Markers.EMPTY,
                     Space.build("\n"));

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -1173,7 +1173,7 @@ public interface Docker extends Tree {
         Space prefix;
 
         Space execFormPrefix;
-        List<DockerRightPadded<Literal>> paths;
+        List<Literal> paths;
         Space execFormSuffix;
 
         Markers markers;
@@ -1210,8 +1210,7 @@ public interface Docker extends Tree {
                                     .withPrefix(form == Form.EXEC ? Space.EMPTY : Space.build(" "))
                                     .withTrailing(Space.EMPTY)
                             )
-                            .map(DockerRightPadded::build)
-                            .collect(Collectors.toCollection(ArrayList::new)),
+                            .collect(Collectors.toList()),
                     Space.EMPTY,
                     Markers.EMPTY,
                     Space.build("\n"));

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Docker.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import static com.github.jimschubert.rewrite.docker.internal.StringUtil.trimDoubleQuotes;
 import static com.github.jimschubert.rewrite.docker.internal.StringUtil.trimSingleQuotes;
 
-// TODO: maybe revisit some of the types here to determine if any can be simplified (e.g. DockerRightPadded<Literal>)
 // TODO: maybe add helper methods to simplify setting of (most) fields?
 
 /**
@@ -334,13 +333,13 @@ public interface Docker extends Tree {
         public static Arg build(String key, String value) {
             return new Arg(Tree.randomId(), Space.EMPTY, List.of(
                     DockerRightPadded.build(new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(value), true, Quoting.UNQUOTED))
-            ), Markers.EMPTY, Space.build("\n"));
+            ), Markers.EMPTY, Space.NEWLINE);
         }
 
         public static Arg build(KeyArgs... args) {
             return new Arg(Tree.randomId(), Space.EMPTY, Arrays.stream(args)
                     .map(DockerRightPadded::build)
-                    .collect(Collectors.toCollection(ArrayList::new)), Markers.EMPTY, Space.build("\n"));
+                    .collect(Collectors.toCollection(ArrayList::new)), Markers.EMPTY, Space.NEWLINE);
         }
     }
 
@@ -389,7 +388,7 @@ public interface Docker extends Tree {
                             .collect(Collectors.toList()),
                     Space.EMPTY,
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -428,7 +427,7 @@ public interface Docker extends Tree {
                     Space.EMPTY,
                     Literal.build(text).withPrefix(Space.build(" ")),
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -531,7 +530,7 @@ public interface Docker extends Tree {
                             new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(value), true, Quoting.UNQUOTED)
                     ),
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -582,7 +581,7 @@ public interface Docker extends Tree {
                             .collect(Collectors.toList()),
                     Space.EMPTY,
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -624,7 +623,7 @@ public interface Docker extends Tree {
                             )
                     ),
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
 
         public static Env build(KeyArgs... args) {
@@ -638,7 +637,7 @@ public interface Docker extends Tree {
                     .map(DockerRightPadded::build)
                     .collect(Collectors.toCollection(ArrayList::new)),
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -698,7 +697,7 @@ public interface Docker extends Tree {
                     Space.EMPTY,
                     portsList,
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -808,7 +807,7 @@ public interface Docker extends Tree {
                     Literal.build(null).withPrefix(Space.build(" ")),
                     Space.EMPTY,
                     Markers.EMPTY,
-                    Space.build("\n")).image(image);
+                    Space.NEWLINE).image(image);
         }
 
         public static From build(String prefix, String platform, String image, String version, String alias) {
@@ -820,7 +819,7 @@ public interface Docker extends Tree {
                     Literal.build(alias).withPrefix(Space.build(" ")),
                     Space.EMPTY,
                     Markers.EMPTY,
-                    Space.build("\n")
+                    Space.NEWLINE
             )
                     .image(image)
                     .version(version)
@@ -904,13 +903,13 @@ public interface Docker extends Tree {
         public static Label build(String key, String value) {
             return new Label(Tree.randomId(), Space.EMPTY, List.of(
                     DockerRightPadded.build(new KeyArgs(Space.build(" "), Literal.build(key), Literal.build(value), true, Quoting.UNQUOTED))
-            ), Markers.EMPTY, Space.build("\n"));
+            ), Markers.EMPTY, Space.NEWLINE);
         }
 
         public static Label build(KeyArgs... args) {
             return new Label(Tree.randomId(), Space.EMPTY, Arrays.stream(args)
                     .map(DockerRightPadded::build)
-                    .collect(Collectors.toCollection(ArrayList::new)), Markers.EMPTY, Space.build("\n"));
+                    .collect(Collectors.toCollection(ArrayList::new)), Markers.EMPTY, Space.NEWLINE);
         }
     }
 
@@ -957,7 +956,7 @@ public interface Docker extends Tree {
 
             return new Maintainer(Tree.randomId(), quoting, Space.EMPTY,
                     Literal.build(name).withPrefix(Space.build(" ")),
-                    Markers.EMPTY, Space.build("\n"));
+                    Markers.EMPTY, Space.NEWLINE);
         }
     }
 
@@ -992,7 +991,7 @@ public interface Docker extends Tree {
         }
 
         public static OnBuild build(Docker instruction) {
-            return new OnBuild(Tree.randomId(), Space.EMPTY, instruction, Space.EMPTY, Markers.EMPTY, Space.build("\n"));
+            return new OnBuild(Tree.randomId(), Space.EMPTY, instruction, Space.EMPTY, Markers.EMPTY, Space.NEWLINE);
         }
     }
 
@@ -1034,7 +1033,7 @@ public interface Docker extends Tree {
                             .map(s -> Literal.build(s).withPrefix(Space.build(" ")))
                             .collect(Collectors.toList()),
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -1078,7 +1077,7 @@ public interface Docker extends Tree {
                             .collect(Collectors.toList()),
                     Space.EMPTY,
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -1113,7 +1112,7 @@ public interface Docker extends Tree {
                     Space.EMPTY,
                     Literal.build(signal).withPrefix(Space.build(" ")),
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -1156,7 +1155,7 @@ public interface Docker extends Tree {
                     username == null ? null : Literal.build(username).withPrefix(Space.build(" ")),
                     group == null ? null : Literal.build(group).withPrefix(Space.build(" ")),
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -1213,7 +1212,7 @@ public interface Docker extends Tree {
                             .collect(Collectors.toList()),
                     Space.EMPTY,
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -1281,7 +1280,7 @@ public interface Docker extends Tree {
                     Space.EMPTY,
                     Literal.build(path).withPrefix(Space.build(" ")),
                     Markers.EMPTY,
-                    Space.build("\n"));
+                    Space.NEWLINE);
         }
     }
 
@@ -1328,14 +1327,6 @@ public interface Docker extends Tree {
         }
     }
 
-//    @Value
-//    @With
-//    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-//    class SecurityOption {
-//        Space prefix;
-//        String name;
-//    }
-
     @Value
     @With
     @EqualsAndHashCode
@@ -1345,23 +1336,4 @@ public interface Docker extends Tree {
         String protocol;
         boolean protocolProvided;
     }
-
-//    @Value
-//    @With
-//    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-//    class NetworkOption {
-//        Space prefix;
-//        String name;
-//    }
-
-//    // TODO: Extends Dockerfile, add visitor
-//    @Value
-//    @With
-//    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
-//    class Mount{
-//        Space prefix;
-//        String type;
-//        List<KeyArgs> options;
-//        String id;
-//    }
 }

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
@@ -433,23 +433,22 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
             p.append("[");
         }
 
-        List<DockerRightPadded<Docker.Literal>> commands = entrypoint.getCommands();
+        List<Docker.Literal> commands = entrypoint.getCommands();
         for (int i = 0; i < commands.size(); i++) {
-            DockerRightPadded<Docker.Literal> padded = commands.get(i);
+            Docker.Literal padded = commands.get(i);
 
             if (entrypoint.getForm() == Form.SHELL
                 && i > 0
                 && i < commands.size() - 1
-                && "".equals(padded.getElement().getPrefix().getWhitespace())) {
+                && "".equals(padded.getPrefix().getWhitespace())) {
                 p.append(" ");
             }
 
-            visitDockerRightPaddedLiteral(padded, p);
+            visitLiteral(padded, p);
 
             if (i < commands.size() - 1 && entrypoint.getForm() == Form.EXEC) {
                 p.append(",");
             }
-            visitSpace(padded.getAfter(), p);
         }
         if (entrypoint.getForm() == Form.EXEC) {
             p.append("]");

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
@@ -623,23 +623,18 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
         p.append("[");
 
         for (int i = 0; i < shell.getCommands().size(); i++) {
-            DockerRightPadded<Docker.Literal> padded = shell.getCommands().get(i);
-            Docker.Literal literal = padded.getElement();
+            Docker.Literal literal = shell.getCommands().get(i);
             if (literal.getQuoting() != Quoting.DOUBLE_QUOTED) {
                 literal = ((Docker.Literal) literal.copyPaste())
                         .withQuoting(Quoting.DOUBLE_QUOTED)
                         .withText(trimDoubleQuotes(literal.getText()));
-                padded = DockerRightPadded.build(literal)
-                        .withMarkers(padded.getMarkers())
-                        .withAfter(padded.getAfter());
             }
 
-            visitDockerRightPaddedLiteral(padded, p);
+            visitLiteral(literal, p);
 
             if (i < shell.getCommands().size() - 1) {
                 p.append(",");
             }
-            visitSpace(padded.getAfter(), p);
         }
 
         p.append("]");

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
@@ -389,11 +389,11 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
 
         if (add.getSources() != null) {
             for (int i = 0; i < add.getSources().size(); i++) {
-                visitDockerRightPaddedLiteral(add.getSources().get(i), p);
+                visitLiteral(add.getSources().get(i), p);
             }
         }
 
-        visitDockerRightPaddedLiteral(add.getDestination(), p);
+        visitLiteral(add.getDestination(), p);
 
         afterSyntax(add, p);
         return add;

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
@@ -587,25 +587,24 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
 
         if (healthcheck.getCommands() != null) {
             for (int i = 0; i < healthcheck.getCommands().size(); i++) {
-                DockerRightPadded<Docker.Literal> padded = healthcheck.getCommands().get(i);
+                Docker.Literal command = healthcheck.getCommands().get(i);
 
-                if (i == 0 && "CMD".equals(padded.getElement().getText())) {
-                    if (padded.getElement().getPrefix().isEmpty()) {
+                if (i == 0 && "CMD".equals(command.getText())) {
+                    if (command.getPrefix().isEmpty()) {
                         p.append(" ");
                     }
                     p.append("CMD");
-                    visitSpace(padded.getElement().getPrefix(), p);
+                    visitSpace(command.getPrefix(), p);
                     continue;
                 } else if (i == 0) {
                     p.append(" CMD");
                 }
 
-                if (i > 0 && "".equals(padded.getElement().getPrefix().getWhitespace())) {
+                if (i > 0 && "".equals(command.getPrefix().getWhitespace())) {
                     p.append(" ");
                 }
 
-                visitLiteral(padded.getElement(), p);
-                visitSpace(padded.getAfter(), p);
+                visitLiteral(command, p);
             }
         }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
@@ -206,8 +206,7 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
         }
 
         for (int i = 0; i < cmd.getCommands().size(); i++) {
-            DockerRightPadded<Docker.Literal> padded = cmd.getCommands().get(i);
-            Docker.Literal literal = padded.getElement();
+            Docker.Literal literal = cmd.getCommands().get(i);
             String text = literal.getText();
             visitSpace(literal.getPrefix(), p);
 
@@ -220,7 +219,7 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
             } else {
                 p.append(text);
             }
-            visitSpace(padded.getAfter(), p);
+            visitSpace(literal.getTrailing(), p);
         }
 
         if (form == Form.EXEC) {

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
@@ -434,16 +434,16 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
 
         List<Docker.Literal> commands = entrypoint.getCommands();
         for (int i = 0; i < commands.size(); i++) {
-            Docker.Literal padded = commands.get(i);
+            Docker.Literal literal = commands.get(i);
 
             if (entrypoint.getForm() == Form.SHELL
                 && i > 0
                 && i < commands.size() - 1
-                && "".equals(padded.getPrefix().getWhitespace())) {
+                && "".equals(literal.getPrefix().getWhitespace())) {
                 p.append(" ");
             }
 
-            visitLiteral(padded, p);
+            visitLiteral(literal, p);
 
             if (i < commands.size() - 1 && entrypoint.getForm() == Form.EXEC) {
                 p.append(",");
@@ -472,21 +472,19 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
         }
 
         for (int i = 0; i < volume.getPaths().size(); i++) {
-            DockerRightPadded<Docker.Literal> padded = volume.getPaths().get(i);
+            Docker.Literal literal = volume.getPaths().get(i);
             if (volume.getForm() == Form.SHELL
                 && i > 0
                 && i < volume.getPaths().size() - 1
-                && "".equals(padded.getElement().getPrefix().getWhitespace())) {
+                && "".equals(literal.getPrefix().getWhitespace())) {
                 p.append(" ");
             }
 
-            visitDockerRightPaddedLiteral(padded, p);
+            visitLiteral(literal, p);
 
             if (volume.getForm() == Form.EXEC && i < volume.getPaths().size() - 1) {
                 p.append(",");
             }
-
-            visitSpace(padded.getAfter(), p);
         }
 
         if (volume.getForm() == Form.EXEC) {

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
@@ -176,14 +176,13 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
         p.append("RUN");
         if (run.getOptions() != null) {
             run.getOptions().forEach(o -> {
-                visitOption(o.getElement(), p);
-                visitSpace(o.getAfter(), p);
+                visitOption(o, p);
             });
         }
 
         if (run.getCommands() != null) {
             for (int i = 0; i < run.getCommands().size(); i++) {
-                visitDockerRightPaddedLiteral(run.getCommands().get(i), p);
+                visitLiteral(run.getCommands().get(i), p);
             }
         }
 

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
@@ -109,29 +109,26 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
     public Docker visitFrom(Docker.From from, PrintOutputCapture<P> p) {
         beforeSyntax(from, p);
         p.append("FROM");
-        if (from.getPlatform() != null && !StringUtils.isBlank(from.getPlatform().getElement().getText())) {
-            visitSpace(from.getPlatform().getElement().getPrefix(), p);
-            if (!from.getPlatform().getElement().getText().startsWith("--")) {
-                if (from.getPlatform().getElement().getPrefix().getWhitespace() == "") {
+        if (from.getPlatform() != null && !StringUtils.isBlank(from.getPlatform().getText())) {
+            visitSpace(from.getPlatform().getPrefix(), p);
+            if (!from.getPlatform().getText().startsWith("--")) {
+                if ("".equals(from.getPlatform().getPrefix().getWhitespace())) {
                     p.append(" ");
                 }
                 p.append("--platform=");
             }
 
-            p.append(from.getPlatform().getElement().getText());
-            visitSpace(from.getPlatform().getElement().getTrailing(), p);
-            visitSpace(from.getPlatform().getAfter(), p);
+            p.append(from.getPlatform().getText());
+            visitSpace(from.getPlatform().getTrailing(), p);
         }
 
-        appendRightPaddedLiteral(from.getImage(), p);
-        appendRightPaddedLiteral(from.getVersion(), p);
+        visitLiteral(from.getImage(), p);
+        visitLiteral(from.getVersion(), p);
 
         if (from.getAlias() != null &&
-            from.getAlias().getElement() != null &&
-            from.getAlias().getElement().getText() != null) {
-            visitSpace(from.getAs().getPrefix(), p);
-            p.append(from.getAs().getText());
-            appendRightPaddedLiteral(from.getAlias(), p);
+            from.getAlias().getText() != null) {
+            visitLiteral(from.getAs(), p);
+            visitLiteral(from.getAlias(), p);
         }
 
         afterSyntax(from, p);

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
@@ -382,8 +382,7 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
 
         if (add.getOptions() != null) {
             add.getOptions().forEach(o -> {
-                visitOption(o.getElement(), p);
-                visitSpace(o.getAfter(), p);
+                visitOption(o, p);
             });
         }
 
@@ -406,18 +405,17 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
 
         if (copy.getOptions() != null) {
             copy.getOptions().forEach(o -> {
-                visitOption(o.getElement(), p);
-                visitSpace(o.getAfter(), p);
+                visitOption(o, p);
             });
         }
 
         if (copy.getSources() != null) {
             for (int i = 0; i < copy.getSources().size(); i++) {
-                visitDockerRightPaddedLiteral(copy.getSources().get(i), p);
+                visitLiteral(copy.getSources().get(i), p);
             }
         }
 
-        visitDockerRightPaddedLiteral(copy.getDestination(), p);
+        visitLiteral(copy.getDestination(), p);
 
         afterSyntax(copy, p);
         return copy;

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinter.java
@@ -148,13 +148,11 @@ public class DockerfilePrinter<P> extends DockerVisitor<PrintOutputCapture<P>> {
 
     @Override
     public Docker visitComment(Docker.Comment comment, PrintOutputCapture<P> p) {
-        Docker.Literal literal = comment.getText().getElement();
+        Docker.Literal literal = comment.getText();
         if (literal != null) {
             beforeSyntax(comment, p);
             p.append("#");
-            visitSpace(literal.getPrefix(), p);
-            p.append(literal.getText().replace("\n", "\n# "));
-            visitSpace(comment.getText().getAfter(), p);
+            visitLiteral(literal.withText(literal.getText().replaceAll("\n", "\n# ")), p);
             afterSyntax(comment, p);
         }
         return comment;

--- a/src/main/java/com/github/jimschubert/rewrite/docker/tree/Space.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/tree/Space.java
@@ -32,6 +32,7 @@ import java.util.function.UnaryOperator;
 @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
 public class Space {
     public static final Space EMPTY = new Space("");
+    public static final Space NEWLINE = new Space("\n");
 
     @Nullable
     private final String whitespace;

--- a/src/test/java/com/github/jimschubert/rewrite/docker/AsDockerfileTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/AsDockerfileTest.java
@@ -42,8 +42,8 @@ class AsDockerfileTest implements RewriteTest {
         assertThat(doc.getStages().get(0)).isNotNull();
 
         Docker.From from =(Docker.From)doc.getStages().get(0).getChildren().get(0);
-        assertThat(from.getImage().getElement().getText()).isEqualTo("alpine");
-        assertThat(from.getVersion().getElement().getText()).isEqualTo(":latest");
+        assertThat(from.getImage().getText()).isEqualTo("alpine");
+        assertThat(from.getVersion().getText()).isEqualTo(":latest");
     }
 
     @Test

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserHelpers.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserHelpers.java
@@ -147,7 +147,7 @@ public class DockerParserHelpers {
         assertEquals(expectedQuoting, value.getQuoting(),
                 "Expected Literal quoting to be '" + expectedQuoting + "' but was '" + value.getQuoting() + "'");
         assertEquals(expectedTrailing, value.getTrailing().getWhitespace(),
-                "Expected Literal trailing whitespace to be '" + expectedTrailing + "' but was '" + value.getTrailing() + "'");
+                "Expected Literal trailing whitespace to be '" + printableWhiteSpace(expectedTrailing) + "' but was '" + printableWhiteSpace(value.getTrailing().getWhitespace()) + "'");
     }
 
     public static void assertOption(

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserHelpers.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerParserHelpers.java
@@ -44,16 +44,14 @@ public class DockerParserHelpers {
     }
 
     public static void assertComment(Docker.Comment comment, String expectedPrefix, String expectedText, String expectedAfter) {
-        DockerRightPadded<Docker.Literal> value = comment.getText();
+        Docker.Literal value = comment.getText();
 
-        assertNotNull(value.getElement(),
-                "Expected Comment to have an element but was null");
-        assertEquals(expectedAfter, value.getAfter().getWhitespace(),
-                "Expected Comment to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getAfter().getWhitespace()) + "'");
-        assertEquals(expectedText, value.getElement().getText(),
-                "Expected Comment text to be '" + expectedText + "' but was '" + value.getElement().getText() + "'");
-        assertEquals(expectedPrefix, value.getElement().getPrefix().getWhitespace(),
-                "Expected Comment prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getElement().getPrefix().getWhitespace()) + "'");
+        assertEquals(expectedAfter, value.getTrailing().getWhitespace(),
+                "Expected Comment to have trailing whitespace '" + printableWhiteSpace(expectedAfter) + "' but was '" + printableWhiteSpace(value.getTrailing().getWhitespace()) + "'");
+        assertEquals(expectedText, value.getText(),
+                "Expected Comment text to be '" + expectedText + "' but was '" + value.getText() + "'");
+        assertEquals(expectedPrefix, value.getPrefix().getWhitespace(),
+                "Expected Comment prefix whitespace to be '" + printableWhiteSpace(expectedPrefix) + "' but was '" + printableWhiteSpace(value.getPrefix().getWhitespace()) + "'");
     }
 
     public static void assertDirective(Docker.Directive directive, String expectedPrefix, String expectedKey, boolean hasEquals, String expectedValue, String expectedAfter) {

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
@@ -146,8 +146,8 @@ class DockerfileParserTest {
         List<Docker.Literal> args = cmd.getCommands();
         assertEquals(3, args.size());
 
-        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo",  "");
-        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello",  "");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
         assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "   ");
     }
 
@@ -164,7 +164,7 @@ class DockerfileParserTest {
         List<Docker.Literal> args = cmd.getCommands();
         assertEquals(1, args.size());
 
-        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo Hello World",  "   ");
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo Hello World", "   ");
         assertEquals("", cmd.getExecFormSuffix().getWhitespace());
         assertEquals("", cmd.getExecFormPrefix().getWhitespace());
     }
@@ -182,9 +182,9 @@ class DockerfileParserTest {
         List<Docker.Literal> args = cmd.getCommands();
         assertEquals(3, args.size());
 
-        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo",  "");
-        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello",  "");
-        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World",  "   ");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "   ");
     }
 
     @Test
@@ -220,8 +220,8 @@ class DockerfileParserTest {
         assertEquals(3, args.size());
 
         assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
-        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello",  "");
-        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World",  "   ");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "   ");
     }
 
     @Test
@@ -237,7 +237,7 @@ class DockerfileParserTest {
         List<Docker.Literal> args = entrypoint.getCommands();
         assertEquals(1, args.size());
 
-        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo Hello World",  "   ");
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo Hello World", "   ");
     }
 
     @Test
@@ -651,8 +651,8 @@ class DockerfileParserTest {
         assertEquals(4, args.size());
 
         assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt", " \\\n\t\t");
-        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt",  " \\\n\t\t");
-        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt",  " \\\n\t\t");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt", " \\\n\t\t");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt", " \\\n\t\t");
         assertLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt", "");
 
         Docker.Literal dest = add.getDestination();
@@ -672,10 +672,10 @@ class DockerfileParserTest {
         List<Docker.Literal> args = add.getSources();
         assertEquals(4, args.size());
 
-        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt",  " \\\n\t\t");
-        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt",  " \\\n\t\t");
-        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt",  " \\\n\t\t");
-        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt",  "");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt", " \\\n\t\t");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt", " \\\n\t\t");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt", " \\\n\t\t");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt", "");
 
         Docker.Literal dest = add.getDestination();
         assertLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "\t");
@@ -700,10 +700,10 @@ class DockerfileParserTest {
         List<Docker.Literal> args = copy.getSources();
         assertEquals(4, args.size());
 
-        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt",  " \\\n\t\t");
-        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt",  " \\\n\t\t");
-        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt",  " \\\n\t\t");
-        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt",  "");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt", " \\\n\t\t");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt", " \\\n\t\t");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt", " \\\n\t\t");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt", "");
 
         Docker.Literal dest = copy.getDestination();
         assertLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "\t");
@@ -734,9 +734,9 @@ class DockerfileParserTest {
         assertEquals(4, args.size());
 
         assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "<<EOF", "");
-        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "/usr/share/nginx/html/index.html",  "\n");
-        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "(your index page goes here)",  "\n");
-        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "EOF",  "\n");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "/usr/share/nginx/html/index.html", "\n");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "(your index page goes here)", "\n");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "EOF", "\n");
     }
 
     @Test
@@ -749,12 +749,12 @@ class DockerfileParserTest {
         Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(3, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "", "\t");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "\t");
     }
 
     @Test
@@ -772,26 +772,26 @@ class DockerfileParserTest {
         Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Option>> opts = cmd.getOptions();
+        List<Docker.Option> opts = cmd.getOptions();
         assertEquals(2, opts.size());
 
-        assertOption(opts.get(0).getElement(), Quoting.UNQUOTED, " ", "--mount", true, "type=cache,target=/var/cache/apt,sharing=locked");
-        assertEquals(" \\\n", opts.get(0).getAfter().getWhitespace());
+        assertOption(opts.get(0), Quoting.UNQUOTED, " ", "--mount", true, "type=cache,target=/var/cache/apt,sharing=locked");
+        assertEquals(" \\\n", opts.get(0).getTrailing().getWhitespace());
 
-        assertOption(opts.get(1).getElement(), Quoting.UNQUOTED, "  ", "--mount", true, "type=cache,target=/var/lib/apt,sharing=locked");
-        assertEquals(" \\\n", opts.get(1).getAfter().getWhitespace());
+        assertOption(opts.get(1), Quoting.UNQUOTED, "  ", "--mount", true, "type=cache,target=/var/lib/apt,sharing=locked");
+        assertEquals(" \\\n", opts.get(1).getTrailing().getWhitespace());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(8, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, "  ", "apt", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "update", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", "&&", "", "");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, " ", "apt-get", "", "");
-        assertRightPaddedLiteral(args.get(4), Quoting.UNQUOTED, " ", "--no-install-recommends", "", "");
-        assertRightPaddedLiteral(args.get(5), Quoting.UNQUOTED, " ", "install", "", "");
-        assertRightPaddedLiteral(args.get(6), Quoting.UNQUOTED, " ", "-y", "", "");
-        assertRightPaddedLiteral(args.get(7), Quoting.UNQUOTED, " ", "gcc", "", "");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, "  ", "apt", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "update", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "&&", "");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, " ", "apt-get", "");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, " ", "--no-install-recommends", "");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, " ", "install", "");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, " ", "-y", "");
+        assertLiteral(args.get(7), Quoting.UNQUOTED, " ", "gcc", "");
     }
 
     /**
@@ -817,25 +817,25 @@ class DockerfileParserTest {
         Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(8, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "<<EOF", "", "\n");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, "", "apt-get", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", "update", "", "\n");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, "", "apt-get", "", "");
-        assertRightPaddedLiteral(args.get(4), Quoting.UNQUOTED, " ", "install", "", "");
-        assertRightPaddedLiteral(args.get(5), Quoting.UNQUOTED, " ", "-y", "", "");
-        assertRightPaddedLiteral(args.get(6), Quoting.UNQUOTED, " ", "curl", "", "\n");
-        assertRightPaddedLiteral(args.get(7), Quoting.UNQUOTED, "", "EOF", "", "\n");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "<<EOF", "\n");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "apt-get", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "update", "\n");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "apt-get", "");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, " ", "install", "");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, " ", "-y", "");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, " ", "curl", "\n");
+        assertLiteral(args.get(7), Quoting.UNQUOTED, "", "EOF", "\n");
     }
 
     /**
      * Tests this example from docker blog @ <a href="https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/">...</a>
      * RUN python3 <<EOF
      * with open("/hello", "w") as f:
-     *     print("Hello", file=f)
-     *     print("World", file=f)
+     * print("Hello", file=f)
+     * print("World", file=f)
      * EOF
      */
     @Test
@@ -855,19 +855,19 @@ class DockerfileParserTest {
         Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(9, args.size());
 
         // TODO: within heredocs, collect literals wrapped via () and [] along with single and double quoted strings
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "python3", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "<<EOF", "", "\n");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, "", "with", "", "");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, " ", "open(\"/hello\", \"w\")", "", "");
-        assertRightPaddedLiteral(args.get(4), Quoting.UNQUOTED, " ", "as", "", "");
-        assertRightPaddedLiteral(args.get(5), Quoting.UNQUOTED, " ", "f:", "", "\n");
-        assertRightPaddedLiteral(args.get(6), Quoting.UNQUOTED, "    ", "print(\"Hello\", file=f)", "", "\n");
-        assertRightPaddedLiteral(args.get(7), Quoting.UNQUOTED, "    ", "print(\"World\", file=f)", "", "\n");
-        assertRightPaddedLiteral(args.get(8), Quoting.UNQUOTED, "", "EOF", "", "\n");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "python3", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "<<EOF", "\n");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "with", "");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, " ", "open(\"/hello\", \"w\")", "");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, " ", "as", "");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, " ", "f:", "\n");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, "    ", "print(\"Hello\", file=f)", "\n");
+        assertLiteral(args.get(7), Quoting.UNQUOTED, "    ", "print(\"World\", file=f)", "\n");
+        assertLiteral(args.get(8), Quoting.UNQUOTED, "", "EOF", "\n");
     }
 
     /**
@@ -893,16 +893,16 @@ class DockerfileParserTest {
         Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(7, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "python3", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "<<EOF", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", ">", "", "");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, " ", "/hello", "", "\n");
-        assertRightPaddedLiteral(args.get(4), Quoting.UNQUOTED, "", "print(\"Hello\")", "", "\n");
-        assertRightPaddedLiteral(args.get(5), Quoting.UNQUOTED, "", "print(\"World\")", "", "\n");
-        assertRightPaddedLiteral(args.get(6), Quoting.UNQUOTED, "", "EOF", "", "\n");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "python3", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "<<EOF", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", ">", "");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, " ", "/hello", "\n");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, "", "print(\"Hello\")", "\n");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, "", "print(\"World\")", "\n");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, "", "EOF", "\n");
     }
 
     @Test
@@ -921,20 +921,20 @@ class DockerfileParserTest {
         Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(11, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "", "");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, " ", "<<EOF", "", "\n");
-        assertRightPaddedLiteral(args.get(4), Quoting.UNQUOTED, "", "apt-get", "", "");
-        assertRightPaddedLiteral(args.get(5), Quoting.UNQUOTED, " ", "update", "", "\n");
-        assertRightPaddedLiteral(args.get(6), Quoting.UNQUOTED, "", "apt-get", "", "");
-        assertRightPaddedLiteral(args.get(7), Quoting.UNQUOTED, " ", "install", "", "");
-        assertRightPaddedLiteral(args.get(8), Quoting.UNQUOTED, " ", "-y", "", "");
-        assertRightPaddedLiteral(args.get(9), Quoting.UNQUOTED, " ", "curl", "", "\n");
-        assertRightPaddedLiteral(args.get(10), Quoting.UNQUOTED, "", "EOF", "", "\n");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, " ", "<<EOF", "\n");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, "", "apt-get", "");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, " ", "update", "\n");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, "", "apt-get", "");
+        assertLiteral(args.get(7), Quoting.UNQUOTED, " ", "install", "");
+        assertLiteral(args.get(8), Quoting.UNQUOTED, " ", "-y", "");
+        assertLiteral(args.get(9), Quoting.UNQUOTED, " ", "curl", "\n");
+        assertLiteral(args.get(10), Quoting.UNQUOTED, "", "EOF", "\n");
     }
 
     @Test
@@ -969,9 +969,9 @@ class DockerfileParserTest {
 
         Docker.Run run = (Docker.Run) stage.getChildren().get(1);
         assertEquals(Space.EMPTY, run.getPrefix());
-        assertRightPaddedLiteral(run.getCommands().get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(run.getCommands().get(1), Quoting.UNQUOTED, " ", "Hello", "", "");
-        assertRightPaddedLiteral(run.getCommands().get(2), Quoting.UNQUOTED, " ", "World", "", "");
+        assertLiteral(run.getCommands().get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(run.getCommands().get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(run.getCommands().get(2), Quoting.UNQUOTED, " ", "World", "");
 
 
         Docker.Cmd cmd = (Docker.Cmd) stage.getChildren().get(2);
@@ -1063,11 +1063,11 @@ class DockerfileParserTest {
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
         Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(3, args.size());
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "", "");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "");
         assertEquals(printableWhiteSpace("\n\n\n"), printableWhiteSpace(doc.getEof().getWhitespace()));
     }
 
@@ -1075,7 +1075,7 @@ class DockerfileParserTest {
     @SuppressWarnings("TrailingWhitespacesInTextBlock")
     void handleMultipleCRLFinEOF() {
         DockerfileParser parser = new DockerfileParser();
-         Docker.Document doc = parser.parse(new ByteArrayInputStream(
+        Docker.Document doc = parser.parse(new ByteArrayInputStream(
                 """
                 RUN echo Hello World
                 \r
@@ -1086,11 +1086,11 @@ class DockerfileParserTest {
         Docker.Stage stage = assertSingleStageWithChildCount(doc, 1);
         Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(3, args.size());
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "", "");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "");
         assertEquals(printableWhiteSpace("\r\n\r\n\r\n"), printableWhiteSpace(doc.getEof().getWhitespace()));
     }
 
@@ -1099,23 +1099,23 @@ class DockerfileParserTest {
         DockerfileParser parser = new DockerfileParser();
 
         Docker.Document doc = parser.parse(new ByteArrayInputStream(
-            """
-            FROM ubuntu:20.04
-            RUN apt-get update && apt-get install -y build-essential
-            RUN echo "Stage 1 complete" > /stage1.txt
-            
-            FROM ubuntu:20.04
-            COPY --from=0 /stage1.txt /stage2.txt
-            RUN echo "Stage 2 complete" > /stage2_complete.txt
-            
-            FROM ubuntu:20.04
-            COPY --from=1 /stage2_complete.txt /stage3.txt
-            RUN echo "Stage 3 complete" > /stage3_complete.txt
-            
-            FROM ubuntu:20.04
-            COPY --from=2 /stage3_complete.txt /final_stage.txt
-            CMD ["cat", "/final_stage.txt"]
-            """.getBytes(StandardCharsets.UTF_8)));
+                """
+                FROM ubuntu:20.04
+                RUN apt-get update && apt-get install -y build-essential
+                RUN echo "Stage 1 complete" > /stage1.txt
+                
+                FROM ubuntu:20.04
+                COPY --from=0 /stage1.txt /stage2.txt
+                RUN echo "Stage 2 complete" > /stage2_complete.txt
+                
+                FROM ubuntu:20.04
+                COPY --from=1 /stage2_complete.txt /stage3.txt
+                RUN echo "Stage 3 complete" > /stage3_complete.txt
+                
+                FROM ubuntu:20.04
+                COPY --from=2 /stage3_complete.txt /final_stage.txt
+                CMD ["cat", "/final_stage.txt"]
+                """.getBytes(StandardCharsets.UTF_8)));
 
 
         assertNotNull(doc, "Expected document to be non-null but was null");
@@ -1151,25 +1151,25 @@ class DockerfileParserTest {
 
         Docker.Run run = (Docker.Run) stage0.getChildren().get(1);
         assertEquals(Space.EMPTY, run.getPrefix());
-        List<DockerRightPadded<Docker.Literal>> args = run.getCommands();
-        assertEquals(7, args.size());
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "apt-get", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "update", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", "&&", "", "");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, " ", "apt-get", "", "");
-        assertRightPaddedLiteral(args.get(4), Quoting.UNQUOTED, " ", "install", "", "");
-        assertRightPaddedLiteral(args.get(5), Quoting.UNQUOTED, " ", "-y", "", "");
-        assertRightPaddedLiteral(args.get(6), Quoting.UNQUOTED, " ", "build-essential", "", "");
+        List<Docker.Literal> commands = run.getCommands();
+        assertEquals(7, commands.size());
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, " ", "apt-get", "");
+        assertLiteral(commands.get(1), Quoting.UNQUOTED, " ", "update", "");
+        assertLiteral(commands.get(2), Quoting.UNQUOTED, " ", "&&", "");
+        assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "apt-get", "");
+        assertLiteral(commands.get(4), Quoting.UNQUOTED, " ", "install", "");
+        assertLiteral(commands.get(5), Quoting.UNQUOTED, " ", "-y", "");
+        assertLiteral(commands.get(6), Quoting.UNQUOTED, " ", "build-essential", "");
 
 
         run = (Docker.Run) stage0.getChildren().get(2);
         assertEquals(Space.EMPTY, run.getPrefix());
-        args = run.getCommands();
-        assertEquals(4, args.size());
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "Stage 1 complete", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", ">", "", "");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, " ", "/stage1.txt", "", "");
+        commands = run.getCommands();
+        assertEquals(4, commands.size());
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "Stage 1 complete", "");
+        assertLiteral(commands.get(2), Quoting.UNQUOTED, " ", ">", "");
+        assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "/stage1.txt", "");
 
 
         Docker.From from1 = (Docker.From) stage1.getChildren().get(0);
@@ -1193,12 +1193,12 @@ class DockerfileParserTest {
 
         run = (Docker.Run) stage1.getChildren().get(2);
         assertEquals(Space.EMPTY, run.getPrefix());
-        args = run.getCommands();
-        assertEquals(4, args.size());
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "Stage 2 complete", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", ">", "", "");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, " ", "/stage2_complete.txt", "", "");
+        commands = run.getCommands();
+        assertEquals(4, commands.size());
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "Stage 2 complete", "");
+        assertLiteral(commands.get(2), Quoting.UNQUOTED, " ", ">", "");
+        assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "/stage2_complete.txt", "");
 
         Docker.From from2 = (Docker.From) stage2.getChildren().get(0);
         assertEquals(Space.build("\n"), from2.getPrefix());
@@ -1220,12 +1220,12 @@ class DockerfileParserTest {
         assertLiteral(dest, Quoting.UNQUOTED, " ", "/stage3.txt", "");
         run = (Docker.Run) stage2.getChildren().get(2);
         assertEquals(Space.EMPTY, run.getPrefix());
-        args = run.getCommands();
-        assertEquals(4, args.size());
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "Stage 3 complete", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", ">", "", "");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, " ", "/stage3_complete.txt", "", "");
+        commands = run.getCommands();
+        assertEquals(4, commands.size());
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "Stage 3 complete", "");
+        assertLiteral(commands.get(2), Quoting.UNQUOTED, " ", ">", "");
+        assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "/stage3_complete.txt", "");
 
         Docker.From from3 = (Docker.From) finalStage.getChildren().get(0);
         assertEquals(Space.build("\n"), from3.getPrefix());
@@ -1268,22 +1268,22 @@ class DockerfileParserTest {
         Docker.Run cmd = (Docker.Run) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(11, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "", " \\\n");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, "", "#", "", "");
-        assertRightPaddedLiteral(args.get(4), Quoting.UNQUOTED, " ", "This", "", "");
-        assertRightPaddedLiteral(args.get(5), Quoting.UNQUOTED, " ", "is", "", "");
-        assertRightPaddedLiteral(args.get(6), Quoting.UNQUOTED, " ", "a", "", "");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", " \\\n");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "#", "");
+        assertLiteral(args.get(4), Quoting.UNQUOTED, " ", "This", "");
+        assertLiteral(args.get(5), Quoting.UNQUOTED, " ", "is", "");
+        assertLiteral(args.get(6), Quoting.UNQUOTED, " ", "a", "");
 
         // TODO: this should be two separate literals
-        assertRightPaddedLiteral(args.get(7), Quoting.UNQUOTED, " ", "comment\n&&", "", "");
-        assertRightPaddedLiteral(args.get(8), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(9), Quoting.UNQUOTED, " ", "Goodbye", "", "");
-        assertRightPaddedLiteral(args.get(10), Quoting.UNQUOTED, " ", "World", "", "");
+        assertLiteral(args.get(7), Quoting.UNQUOTED, " ", "comment\n&&", "");
+        assertLiteral(args.get(8), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(9), Quoting.UNQUOTED, " ", "Goodbye", "");
+        assertLiteral(args.get(10), Quoting.UNQUOTED, " ", "World", "");
 
     }
 }

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static com.github.jimschubert.rewrite.docker.internal.DockerParserHelpers.*;
-import static com.github.jimschubert.rewrite.docker.internal.DockerParserHelpers.assertRightPaddedLiteral;
 import static org.junit.jupiter.api.Assertions.*;
 
 class DockerfileParserTest {

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
@@ -603,10 +603,10 @@ class DockerfileParserTest {
         Docker.Healthcheck healthCheck = (Docker.Healthcheck) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, healthCheck.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> commands = healthCheck.getCommands();
+        List<Docker.Literal> commands = healthCheck.getCommands();
         assertEquals(1, commands.size());
 
-        assertRightPaddedLiteral(commands.get(0), Quoting.UNQUOTED, " ", "NONE", "", "");
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, " ", "NONE", "");
     }
 
     @Test
@@ -625,16 +625,16 @@ class DockerfileParserTest {
         assertRightPaddedArg(options.get(0), Quoting.UNQUOTED, " ", "--interval", true, "5m", "");
         assertRightPaddedArg(options.get(1), Quoting.UNQUOTED, " ", "--timeout", true, "3s", " \\\n");
 
-        List<DockerRightPadded<Docker.Literal>> commands = healthCheck.getCommands();
+        List<Docker.Literal> commands = healthCheck.getCommands();
         assertEquals(7, commands.size());
 
-        assertRightPaddedLiteral(commands.get(0), Quoting.UNQUOTED, "  ", "CMD", "", "");
-        assertRightPaddedLiteral(commands.get(1), Quoting.UNQUOTED, " ", "curl", "", "");
-        assertRightPaddedLiteral(commands.get(2), Quoting.UNQUOTED, " ", "-f", "", "");
-        assertRightPaddedLiteral(commands.get(3), Quoting.UNQUOTED, " ", "http://localhost/", "", "");
-        assertRightPaddedLiteral(commands.get(4), Quoting.UNQUOTED, " ", "||", "", "");
-        assertRightPaddedLiteral(commands.get(5), Quoting.UNQUOTED, " ", "exit", "", "");
-        assertRightPaddedLiteral(commands.get(6), Quoting.UNQUOTED, " ", "1", "", "");
+        assertLiteral(commands.get(0), Quoting.UNQUOTED, "  ", "CMD", "");
+        assertLiteral(commands.get(1), Quoting.UNQUOTED, " ", "curl", "");
+        assertLiteral(commands.get(2), Quoting.UNQUOTED, " ", "-f", "");
+        assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "http://localhost/", "");
+        assertLiteral(commands.get(4), Quoting.UNQUOTED, " ", "||", "");
+        assertLiteral(commands.get(5), Quoting.UNQUOTED, " ", "exit", "");
+        assertLiteral(commands.get(6), Quoting.UNQUOTED, " ", "1", "");
     }
 
     @Test
@@ -1046,7 +1046,7 @@ class DockerfileParserTest {
         Docker.Healthcheck healthCheck = (Docker.Healthcheck) stage.getChildren().get(11);
         assertEquals(Space.EMPTY, healthCheck.getPrefix());
         assertEquals(1, healthCheck.getCommands().size());
-        assertRightPaddedLiteral(healthCheck.getCommands().get(0), Quoting.UNQUOTED, " ", "NONE", "", "");
+        assertLiteral(healthCheck.getCommands().get(0), Quoting.UNQUOTED, " ", "NONE", "");
     }
 
     @Test

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
@@ -647,16 +647,16 @@ class DockerfileParserTest {
         Docker.Add add = (Docker.Add) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, add.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = add.getSources();
+        List<Docker.Literal> args = add.getSources();
         assertEquals(4, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt", "", " \\\n\t\t");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt", "", " \\\n\t\t");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt", "", " \\\n\t\t");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt", "", "");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt", " \\\n\t\t");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt",  " \\\n\t\t");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt",  " \\\n\t\t");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt", "");
 
-        DockerRightPadded<Docker.Literal> dest = add.getDestination();
-        assertRightPaddedLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "", "\t");
+        Docker.Literal dest = add.getDestination();
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "\t");
     }
 
     @Test
@@ -669,16 +669,16 @@ class DockerfileParserTest {
         Docker.Add add = (Docker.Add) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, add.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = add.getSources();
+        List<Docker.Literal> args = add.getSources();
         assertEquals(4, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt", "", " \\\n\t\t");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt", "", " \\\n\t\t");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt", "", " \\\n\t\t");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt", "", "");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt",  " \\\n\t\t");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt",  " \\\n\t\t");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt",  " \\\n\t\t");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt",  "");
 
-        DockerRightPadded<Docker.Literal> dest = add.getDestination();
-        assertRightPaddedLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "", "\t");
+        Docker.Literal dest = add.getDestination();
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "\t");
 
         List<DockerRightPadded<Docker.Option>> options = add.getOptions();
         assertEquals(3, options.size());

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
@@ -680,17 +680,11 @@ class DockerfileParserTest {
         Docker.Literal dest = add.getDestination();
         assertLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "\t");
 
-        List<DockerRightPadded<Docker.Option>> options = add.getOptions();
+        List<Docker.Option> options = add.getOptions();
         assertEquals(3, options.size());
-
-        assertOption(options.get(0).getElement(), Quoting.UNQUOTED, " ", "--chown", true, "foo:bar");
-        assertEquals("", options.get(0).getAfter().getWhitespace());
-
-        assertOption(options.get(1).getElement(), Quoting.UNQUOTED, " ", "--keep-git-dir", false, null);
-        assertEquals("", options.get(1).getAfter().getWhitespace());
-
-        assertOption(options.get(2).getElement(), Quoting.UNQUOTED, " ", "--checksum", true, "sha256:24454f830c");
-        assertEquals("", options.get(2).getAfter().getWhitespace());
+        assertOption(options.get(0), Quoting.UNQUOTED, " ", "--chown", true, "foo:bar");
+        assertOption(options.get(1), Quoting.UNQUOTED, " ", "--keep-git-dir", false, null);
+        assertOption(options.get(2), Quoting.UNQUOTED, " ", "--checksum", true, "sha256:24454f830c");
     }
 
     @Test
@@ -703,16 +697,16 @@ class DockerfileParserTest {
         Docker.Copy copy = (Docker.Copy) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, copy.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = copy.getSources();
+        List<Docker.Literal> args = copy.getSources();
         assertEquals(4, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt", "", " \\\n\t\t");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt", "", " \\\n\t\t");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt", "", " \\\n\t\t");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt", "", "");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "foo.txt",  " \\\n\t\t");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, "", "bar.txt",  " \\\n\t\t");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "baz.txt",  " \\\n\t\t");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "qux.txt",  "");
 
-        DockerRightPadded<Docker.Literal> dest = copy.getDestination();
-        assertRightPaddedLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "", "\t");
+        Docker.Literal dest = copy.getDestination();
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/tmp/", "\t");
     }
 
     /**
@@ -736,13 +730,13 @@ class DockerfileParserTest {
         Docker.Copy cmd = (Docker.Copy) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getSources();
+        List<Docker.Literal> args = cmd.getSources();
         assertEquals(4, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "<<EOF", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "/usr/share/nginx/html/index.html", "", "\n");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, "", "(your index page goes here)", "", "\n");
-        assertRightPaddedLiteral(args.get(3), Quoting.UNQUOTED, "", "EOF", "", "\n");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "<<EOF", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "/usr/share/nginx/html/index.html",  "\n");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, "", "(your index page goes here)",  "\n");
+        assertLiteral(args.get(3), Quoting.UNQUOTED, "", "EOF",  "\n");
     }
 
     @Test
@@ -1188,14 +1182,14 @@ class DockerfileParserTest {
 
         Docker.Copy copy = (Docker.Copy) stage1.getChildren().get(1);
         assertEquals(Space.EMPTY, copy.getPrefix());
-        List<DockerRightPadded<Docker.Option>> opts = copy.getOptions();
-        assertRightPaddedOption(opts.get(0), Quoting.UNQUOTED, " ", "--from", true, "0", "");
+        List<Docker.Option> opts = copy.getOptions();
+        assertOption(opts.get(0), Quoting.UNQUOTED, " ", "--from", true, "0");
 
-        args = copy.getSources();
-        assertEquals(1, args.size());
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "/stage1.txt", "", "");
-        DockerRightPadded<Docker.Literal> dest = copy.getDestination();
-        assertRightPaddedLiteral(dest, Quoting.UNQUOTED, " ", "/stage2.txt", "", "");
+        List<Docker.Literal> sources = copy.getSources();
+        assertEquals(1, sources.size());
+        assertLiteral(sources.get(0), Quoting.UNQUOTED, " ", "/stage1.txt", "");
+        Docker.Literal dest = copy.getDestination();
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/stage2.txt", "");
 
         run = (Docker.Run) stage1.getChildren().get(2);
         assertEquals(Space.EMPTY, run.getPrefix());
@@ -1217,13 +1211,13 @@ class DockerfileParserTest {
         copy = (Docker.Copy) stage2.getChildren().get(1);
         assertEquals(Space.EMPTY, copy.getPrefix());
         opts = copy.getOptions();
-        args = copy.getSources();
-        assertEquals(1, args.size());
+        sources = copy.getSources();
+        assertEquals(1, sources.size());
 
-        assertRightPaddedOption(opts.get(0), Quoting.UNQUOTED, " ", "--from", true, "1", "");
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "/stage2_complete.txt", "", "");
+        assertOption(opts.get(0), Quoting.UNQUOTED, " ", "--from", true, "1");
+        assertLiteral(sources.get(0), Quoting.UNQUOTED, " ", "/stage2_complete.txt", "");
         dest = copy.getDestination();
-        assertRightPaddedLiteral(dest, Quoting.UNQUOTED, " ", "/stage3.txt", "", "");
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/stage3.txt", "");
         run = (Docker.Run) stage2.getChildren().get(2);
         assertEquals(Space.EMPTY, run.getPrefix());
         args = run.getCommands();
@@ -1245,12 +1239,12 @@ class DockerfileParserTest {
         assertEquals(Space.EMPTY, copy.getPrefix());
 
         opts = copy.getOptions();
-        args = copy.getSources();
-        assertEquals(1, args.size());
-        assertRightPaddedOption(opts.get(0), Quoting.UNQUOTED, " ", "--from", true, "2", "");
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "/stage3_complete.txt", "", "");
+        sources = copy.getSources();
+        assertEquals(1, sources.size());
+        assertOption(opts.get(0), Quoting.UNQUOTED, " ", "--from", true, "2");
+        assertLiteral(sources.get(0), Quoting.UNQUOTED, " ", "/stage3_complete.txt", "");
         dest = copy.getDestination();
-        assertRightPaddedLiteral(dest, Quoting.UNQUOTED, " ", "/final_stage.txt", "", "");
+        assertLiteral(dest, Quoting.UNQUOTED, " ", "/final_stage.txt", "");
 
         Docker.Cmd cmd = (Docker.Cmd) finalStage.getChildren().get(2);
         assertEquals(Space.EMPTY, cmd.getPrefix());

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
@@ -197,11 +197,11 @@ class DockerfileParserTest {
         Docker.Entrypoint entrypoint = (Docker.Entrypoint) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, entrypoint.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = entrypoint.getCommands();
+        List<Docker.Literal> args = entrypoint.getCommands();
         assertEquals(2, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "Hello World", " ", "");
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "Hello World", " ");
 
         assertEquals("   ", entrypoint.getExecFormSuffix().getWhitespace());
     }
@@ -216,12 +216,12 @@ class DockerfileParserTest {
         Docker.Entrypoint entrypoint = (Docker.Entrypoint) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, entrypoint.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = entrypoint.getCommands();
+        List<Docker.Literal> args = entrypoint.getCommands();
         assertEquals(3, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "", "   ");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello",  "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World",  "   ");
     }
 
     @Test
@@ -234,10 +234,10 @@ class DockerfileParserTest {
         Docker.Entrypoint entrypoint = (Docker.Entrypoint) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, entrypoint.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = entrypoint.getCommands();
+        List<Docker.Literal> args = entrypoint.getCommands();
         assertEquals(1, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo Hello World", "", "   ");
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo Hello World",  "   ");
     }
 
     @Test
@@ -984,8 +984,8 @@ class DockerfileParserTest {
         assertEquals(Space.EMPTY, entryPoint.getPrefix());
         assertEquals(2, entryPoint.getCommands().size());
         assertEquals(Form.EXEC, entryPoint.getForm());
-        assertRightPaddedLiteral(entryPoint.getCommands().get(0), Quoting.DOUBLE_QUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(entryPoint.getCommands().get(1), Quoting.DOUBLE_QUOTED, " ", "Hello", " ", "");
+        assertLiteral(entryPoint.getCommands().get(0), Quoting.DOUBLE_QUOTED, " ", "echo", "");
+        assertLiteral(entryPoint.getCommands().get(1), Quoting.DOUBLE_QUOTED, " ", "Hello", " ");
         assertEquals(" ", entryPoint.getExecFormPrefix().getWhitespace());
         assertEquals("", entryPoint.getExecFormSuffix().getWhitespace());
 

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
@@ -1173,7 +1173,7 @@ class DockerfileParserTest {
 
 
         Docker.From from1 = (Docker.From) stage1.getChildren().get(0);
-        assertEquals(Space.build("\n"), from1.getPrefix());
+        assertEquals(Space.NEWLINE, from1.getPrefix());
         assertLiteral(from1.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "");
         assertLiteral(from1.getVersion(), Quoting.UNQUOTED, "", ":20.04", "");
         assertEquals("20.04", from1.getTag());
@@ -1201,7 +1201,7 @@ class DockerfileParserTest {
         assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "/stage2_complete.txt", "");
 
         Docker.From from2 = (Docker.From) stage2.getChildren().get(0);
-        assertEquals(Space.build("\n"), from2.getPrefix());
+        assertEquals(Space.NEWLINE, from2.getPrefix());
         assertLiteral(from2.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "");
         assertLiteral(from2.getVersion(), Quoting.UNQUOTED, "", ":20.04", "");
         assertEquals("20.04", from2.getTag());
@@ -1228,7 +1228,7 @@ class DockerfileParserTest {
         assertLiteral(commands.get(3), Quoting.UNQUOTED, " ", "/stage3_complete.txt", "");
 
         Docker.From from3 = (Docker.From) finalStage.getChildren().get(0);
-        assertEquals(Space.build("\n"), from3.getPrefix());
+        assertEquals(Space.NEWLINE, from3.getPrefix());
         assertLiteral(from3.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "");
         assertLiteral(from3.getVersion(), Quoting.UNQUOTED, "", ":20.04", "");
         assertEquals("20.04", from3.getTag());

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
@@ -360,9 +360,9 @@ class DockerfileParserTest {
         Docker.From from = (Docker.From) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, from.getPrefix());
 
-        assertRightPaddedLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "", "");
+        assertLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "");
         assertEquals("latest", from.getTag());
-        assertEquals("", from.getImage().getAfter().getWhitespace());
+        assertEquals("", from.getImage().getTrailing().getWhitespace());
     }
 
     @Test
@@ -375,12 +375,12 @@ class DockerfileParserTest {
         Docker.From from = (Docker.From) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, from.getPrefix());
 
-        assertRightPaddedLiteral(from.getPlatform(), Quoting.UNQUOTED, " ", "--platform=linux/arm64", "", "");
-        assertRightPaddedLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "", "");
+        assertLiteral(from.getPlatform(), Quoting.UNQUOTED, " ", "--platform=linux/arm64", "");
+        assertLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "");
         assertEquals("latest", from.getTag());
-        assertRightPaddedLiteral(from.getVersion(), Quoting.UNQUOTED, "", ":latest", "", "");
+        assertLiteral(from.getVersion(), Quoting.UNQUOTED, "", ":latest", "");
         assertLiteral(from.getAs(), Quoting.UNQUOTED, " ", "as", "");
-        assertRightPaddedLiteral(from.getAlias(), Quoting.UNQUOTED, " ", "build", "", "\t");
+        assertLiteral(from.getAlias(), Quoting.UNQUOTED, " ", "build", "\t");
     }
 
     @Test
@@ -393,8 +393,8 @@ class DockerfileParserTest {
         Docker.From from = (Docker.From) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, from.getPrefix());
 
-        assertRightPaddedLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "", "");
-        assertRightPaddedLiteral(from.getVersion(), Quoting.UNQUOTED, "", "@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "", "\t");
+        assertLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "");
+        assertLiteral(from.getVersion(), Quoting.UNQUOTED, "", "@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "\t");
         assertEquals("sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", from.getDigest());
     }
 
@@ -966,11 +966,11 @@ class DockerfileParserTest {
 
         Docker.From from = (Docker.From) stage.getChildren().get(0);
 
-        assertRightPaddedLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "", "");
-        assertRightPaddedLiteral(from.getVersion(), Quoting.UNQUOTED, "", ":latest", "", "");
+        assertLiteral(from.getImage(), Quoting.UNQUOTED, " ", "alpine", "");
+        assertLiteral(from.getVersion(), Quoting.UNQUOTED, "", ":latest", "");
         assertEquals("latest", from.getTag());
-        assertRightPaddedLiteral(from.getPlatform(), Quoting.UNQUOTED, "", null, "", "");
-        assertRightPaddedLiteral(from.getAlias(), Quoting.UNQUOTED, "", null, "", "");
+        assertLiteral(from.getPlatform(), Quoting.UNQUOTED, "", null, "");
+        assertLiteral(from.getAlias(), Quoting.UNQUOTED, "", null, "");
         assertLiteral(from.getAs(), Quoting.UNQUOTED, "", null, "");
 
         Docker.Run run = (Docker.Run) stage.getChildren().get(1);
@@ -1148,11 +1148,11 @@ class DockerfileParserTest {
 
         Docker.From from = (Docker.From) stage0.getChildren().get(0);
         assertEquals(Space.EMPTY, from.getPrefix());
-        assertRightPaddedLiteral(from.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "", "");
-        assertRightPaddedLiteral(from.getVersion(), Quoting.UNQUOTED, "", ":20.04", "", "");
+        assertLiteral(from.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "");
+        assertLiteral(from.getVersion(), Quoting.UNQUOTED, "", ":20.04", "");
         assertEquals("20.04", from.getTag());
-        assertRightPaddedLiteral(from.getPlatform(), Quoting.UNQUOTED, "", null, "", "");
-        assertRightPaddedLiteral(from.getAlias(), Quoting.UNQUOTED, "", null, "", "");
+        assertLiteral(from.getPlatform(), Quoting.UNQUOTED, "", null, "");
+        assertLiteral(from.getAlias(), Quoting.UNQUOTED, "", null, "");
 
 
         Docker.Run run = (Docker.Run) stage0.getChildren().get(1);
@@ -1180,11 +1180,11 @@ class DockerfileParserTest {
 
         Docker.From from1 = (Docker.From) stage1.getChildren().get(0);
         assertEquals(Space.build("\n"), from1.getPrefix());
-        assertRightPaddedLiteral(from1.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "", "");
-        assertRightPaddedLiteral(from1.getVersion(), Quoting.UNQUOTED, "", ":20.04", "", "");
+        assertLiteral(from1.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "");
+        assertLiteral(from1.getVersion(), Quoting.UNQUOTED, "", ":20.04", "");
         assertEquals("20.04", from1.getTag());
-        assertRightPaddedLiteral(from1.getPlatform(), Quoting.UNQUOTED, "", null, "", "");
-        assertRightPaddedLiteral(from1.getAlias(), Quoting.UNQUOTED, "", null, "", "");
+        assertLiteral(from1.getPlatform(), Quoting.UNQUOTED, "", null, "");
+        assertLiteral(from1.getAlias(), Quoting.UNQUOTED, "", null, "");
 
         Docker.Copy copy = (Docker.Copy) stage1.getChildren().get(1);
         assertEquals(Space.EMPTY, copy.getPrefix());
@@ -1208,11 +1208,11 @@ class DockerfileParserTest {
 
         Docker.From from2 = (Docker.From) stage2.getChildren().get(0);
         assertEquals(Space.build("\n"), from2.getPrefix());
-        assertRightPaddedLiteral(from2.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "", "");
-        assertRightPaddedLiteral(from2.getVersion(), Quoting.UNQUOTED, "", ":20.04", "", "");
+        assertLiteral(from2.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "");
+        assertLiteral(from2.getVersion(), Quoting.UNQUOTED, "", ":20.04", "");
         assertEquals("20.04", from2.getTag());
-        assertRightPaddedLiteral(from2.getPlatform(), Quoting.UNQUOTED, "", null, "", "");
-        assertRightPaddedLiteral(from2.getAlias(), Quoting.UNQUOTED, "", null, "", "");
+        assertLiteral(from2.getPlatform(), Quoting.UNQUOTED, "", null, "");
+        assertLiteral(from2.getAlias(), Quoting.UNQUOTED, "", null, "");
 
         copy = (Docker.Copy) stage2.getChildren().get(1);
         assertEquals(Space.EMPTY, copy.getPrefix());
@@ -1235,11 +1235,11 @@ class DockerfileParserTest {
 
         Docker.From from3 = (Docker.From) finalStage.getChildren().get(0);
         assertEquals(Space.build("\n"), from3.getPrefix());
-        assertRightPaddedLiteral(from3.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "", "");
-        assertRightPaddedLiteral(from3.getVersion(), Quoting.UNQUOTED, "", ":20.04", "", "");
+        assertLiteral(from3.getImage(), Quoting.UNQUOTED, " ", "ubuntu", "");
+        assertLiteral(from3.getVersion(), Quoting.UNQUOTED, "", ":20.04", "");
         assertEquals("20.04", from3.getTag());
-        assertRightPaddedLiteral(from3.getPlatform(), Quoting.UNQUOTED, "", null, "", "");
-        assertRightPaddedLiteral(from3.getAlias(), Quoting.UNQUOTED, "", null, "", "");
+        assertLiteral(from3.getPlatform(), Quoting.UNQUOTED, "", null, "");
+        assertLiteral(from3.getAlias(), Quoting.UNQUOTED, "", null, "");
 
         copy = (Docker.Copy) finalStage.getChildren().get(1);
         assertEquals(Space.EMPTY, copy.getPrefix());

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
@@ -123,11 +123,11 @@ class DockerfileParserTest {
         Docker.Cmd cmd = (Docker.Cmd) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(2, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "Hello World", " ", "");
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo", "");
+        assertLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "Hello World", " ");
 
         assertEquals(" ", cmd.getExecFormPrefix().getWhitespace());
         assertEquals("   ", cmd.getExecFormSuffix().getWhitespace());
@@ -143,12 +143,12 @@ class DockerfileParserTest {
         Docker.Cmd cmd = (Docker.Cmd) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(3, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "", "   ");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo",  "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello",  "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "   ");
     }
 
     @Test
@@ -161,10 +161,10 @@ class DockerfileParserTest {
         Docker.Cmd cmd = (Docker.Cmd) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(1, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo Hello World", "", "   ");
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "echo Hello World",  "   ");
         assertEquals("", cmd.getExecFormSuffix().getWhitespace());
         assertEquals("", cmd.getExecFormPrefix().getWhitespace());
     }
@@ -179,12 +179,12 @@ class DockerfileParserTest {
         Docker.Cmd cmd = (Docker.Cmd) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, cmd.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> args = cmd.getCommands();
+        List<Docker.Literal> args = cmd.getCommands();
         assertEquals(3, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello", "", "");
-        assertRightPaddedLiteral(args.get(2), Quoting.UNQUOTED, " ", "World", "", "   ");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "echo",  "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "Hello",  "");
+        assertLiteral(args.get(2), Quoting.UNQUOTED, " ", "World",  "   ");
     }
 
     @Test
@@ -976,9 +976,9 @@ class DockerfileParserTest {
 
         Docker.Cmd cmd = (Docker.Cmd) stage.getChildren().get(2);
         assertEquals(Space.EMPTY, cmd.getPrefix());
-        assertRightPaddedLiteral(cmd.getCommands().get(0), Quoting.UNQUOTED, " ", "echo", "", "");
-        assertRightPaddedLiteral(cmd.getCommands().get(1), Quoting.UNQUOTED, " ", "Goodbye", "", "");
-        assertRightPaddedLiteral(cmd.getCommands().get(2), Quoting.UNQUOTED, " ", "World", "", "");
+        assertLiteral(cmd.getCommands().get(0), Quoting.UNQUOTED, " ", "echo", "");
+        assertLiteral(cmd.getCommands().get(1), Quoting.UNQUOTED, " ", "Goodbye", "");
+        assertLiteral(cmd.getCommands().get(2), Quoting.UNQUOTED, " ", "World", "");
 
         Docker.Entrypoint entryPoint = (Docker.Entrypoint) stage.getChildren().get(3);
         assertEquals(Space.EMPTY, entryPoint.getPrefix());
@@ -1248,8 +1248,8 @@ class DockerfileParserTest {
 
         Docker.Cmd cmd = (Docker.Cmd) finalStage.getChildren().get(2);
         assertEquals(Space.EMPTY, cmd.getPrefix());
-        assertRightPaddedLiteral(cmd.getCommands().get(0), Quoting.DOUBLE_QUOTED, "", "cat", "", "");
-        assertRightPaddedLiteral(cmd.getCommands().get(1), Quoting.DOUBLE_QUOTED, " ", "/final_stage.txt", "", "");
+        assertLiteral(cmd.getCommands().get(0), Quoting.DOUBLE_QUOTED, "", "cat", "");
+        assertLiteral(cmd.getCommands().get(1), Quoting.DOUBLE_QUOTED, " ", "/final_stage.txt", "");
         assertEquals(" ", cmd.getExecFormPrefix().getWhitespace());
     }
 

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
@@ -408,11 +408,11 @@ class DockerfileParserTest {
         Docker.Shell shell = (Docker.Shell) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, shell.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> commands = shell.getCommands();
+        List<Docker.Literal> commands = shell.getCommands();
         assertEquals(2, commands.size());
 
-        assertRightPaddedLiteral(commands.get(0), Quoting.DOUBLE_QUOTED, "  ", "powershell", "", "");
-        assertRightPaddedLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "-Command", "   ", "");
+        assertLiteral(commands.get(0), Quoting.DOUBLE_QUOTED, "  ", "powershell", "");
+        assertLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "-Command", "   ");
 
         assertEquals(" ", shell.getExecFormPrefix().getWhitespace());
         assertEquals("\t", shell.getExecFormSuffix().getWhitespace());
@@ -428,13 +428,13 @@ class DockerfileParserTest {
         Docker.Shell shell = (Docker.Shell) stage.getChildren().get(0);
         assertEquals(Space.EMPTY, shell.getPrefix());
 
-        List<DockerRightPadded<Docker.Literal>> commands = shell.getCommands();
+        List<Docker.Literal> commands = shell.getCommands();
         assertEquals(4, commands.size());
 
-        assertRightPaddedLiteral(commands.get(0), Quoting.DOUBLE_QUOTED, "  ", "powershell", "", "");
-        assertRightPaddedLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "-Command", " ", " \t\\\n\t\t  ");
-        assertRightPaddedLiteral(commands.get(2), Quoting.DOUBLE_QUOTED, "", "bash", "", "");
-        assertRightPaddedLiteral(commands.get(3), Quoting.DOUBLE_QUOTED, " ", "-c", "   ", "");
+        assertLiteral(commands.get(0), Quoting.DOUBLE_QUOTED, "  ", "powershell", "");
+        assertLiteral(commands.get(1), Quoting.DOUBLE_QUOTED, " ", "-Command", "  \t\\\n\t\t  ");
+        assertLiteral(commands.get(2), Quoting.DOUBLE_QUOTED, "", "bash", "");
+        assertLiteral(commands.get(3), Quoting.DOUBLE_QUOTED, " ", "-c", "   ");
 
         assertEquals(" ", shell.getExecFormPrefix().getWhitespace());
         assertEquals("", shell.getExecFormSuffix().getWhitespace());
@@ -1011,8 +1011,8 @@ class DockerfileParserTest {
         Docker.Shell shell = (Docker.Shell) stage.getChildren().get(5);
         assertEquals(Space.EMPTY, shell.getPrefix());
         assertEquals(2, shell.getCommands().size());
-        assertRightPaddedLiteral(shell.getCommands().get(0), Quoting.DOUBLE_QUOTED, " ", "powershell", "", "");
-        assertRightPaddedLiteral(shell.getCommands().get(1), Quoting.DOUBLE_QUOTED, " ", "-Command", " ", "");
+        assertLiteral(shell.getCommands().get(0), Quoting.DOUBLE_QUOTED, " ", "powershell", "");
+        assertLiteral(shell.getCommands().get(1), Quoting.DOUBLE_QUOTED, " ", "-Command", " ");
         assertEquals(" ", shell.getExecFormPrefix().getWhitespace());
         assertEquals("", shell.getExecFormSuffix().getWhitespace());
 

--- a/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/internal/DockerfileParserTest.java
@@ -491,11 +491,11 @@ class DockerfileParserTest {
         assertEquals(" ", volume.getExecFormPrefix().getWhitespace());
         assertEquals("\t", volume.getExecFormSuffix().getWhitespace());
 
-        List<DockerRightPadded<Docker.Literal>> args = volume.getPaths();
+        List<Docker.Literal> args = volume.getPaths();
         assertEquals(2, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "/var/log", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "/var/log2", " ", "");
+        assertLiteral(args.get(0), Quoting.DOUBLE_QUOTED, " ", "/var/log", "");
+        assertLiteral(args.get(1), Quoting.DOUBLE_QUOTED, " ", "/var/log2", " ");
     }
 
     @Test
@@ -510,11 +510,11 @@ class DockerfileParserTest {
         assertEquals("", volume.getExecFormPrefix().getWhitespace());
         assertEquals("", volume.getExecFormSuffix().getWhitespace());
 
-        List<DockerRightPadded<Docker.Literal>> args = volume.getPaths();
+        List<Docker.Literal> args = volume.getPaths();
         assertEquals(2, args.size());
 
-        assertRightPaddedLiteral(args.get(0), Quoting.UNQUOTED, " ", "/var/log", "", "");
-        assertRightPaddedLiteral(args.get(1), Quoting.UNQUOTED, " ", "/var/log2", "", "\t");
+        assertLiteral(args.get(0), Quoting.UNQUOTED, " ", "/var/log", "");
+        assertLiteral(args.get(1), Quoting.UNQUOTED, " ", "/var/log2", "\t");
     }
 
     @Test
@@ -1026,8 +1026,8 @@ class DockerfileParserTest {
         assertEquals(" ", volume.getExecFormPrefix().getWhitespace());
         assertEquals("", volume.getExecFormSuffix().getWhitespace());
         assertEquals(2, volume.getPaths().size());
-        assertRightPaddedLiteral(volume.getPaths().get(0), Quoting.DOUBLE_QUOTED, " ", "/var/log", "", "");
-        assertRightPaddedLiteral(volume.getPaths().get(1), Quoting.DOUBLE_QUOTED, " ", "/var/log2", " ", "");
+        assertLiteral(volume.getPaths().get(0), Quoting.DOUBLE_QUOTED, " ", "/var/log", "");
+        assertLiteral(volume.getPaths().get(1), Quoting.DOUBLE_QUOTED, " ", "/var/log2", " ");
 
         Docker.Workdir workdir = (Docker.Workdir) stage.getChildren().get(8);
         assertEquals(Space.EMPTY, workdir.getPrefix());

--- a/src/test/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinterTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinterTest.java
@@ -277,13 +277,9 @@ class DockerfilePrinterTest {
                                         Docker.Option.build("--keep-git-dir", "false"))
                         ),
                         List.of(
-                                DockerRightPadded.build(
-                                        Docker.Literal.build("https://example.com/archive.zip").withPrefix(Space.build(" "))
-                                )
+                            Docker.Literal.build("https://example.com/archive.zip").withPrefix(Space.build(" "))
                         ),
-                        DockerRightPadded.build(
-                                Docker.Literal.build("/usr/src/things/").withPrefix(Space.build(" ")
-                            )
+                            Docker.Literal.build("/usr/src/things/").withPrefix(Space.build(" ")
                         ),
                         Markers.EMPTY,
                         Space.build("\n")

--- a/src/test/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinterTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinterTest.java
@@ -80,7 +80,7 @@ class DockerfilePrinterTest {
     @Test
     void visitRun() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Run.build("echo Hello World").withEol(Space.build("\n")),
+                Docker.Run.build("echo Hello World").withEol(Space.NEWLINE),
                 Docker.Run.build("echo Goodbye World").withEol(Space.EMPTY)
         ).withEof(Space.EMPTY);
 
@@ -281,7 +281,7 @@ class DockerfilePrinterTest {
                             Docker.Literal.build("/usr/src/things/").withPrefix(Space.build(" ")
                         ),
                         Markers.EMPTY,
-                        Space.build("\n")
+                        Space.NEWLINE
                 )
         ).withEof(Space.EMPTY);
 
@@ -305,7 +305,7 @@ class DockerfilePrinterTest {
                         ),
                         Docker.Literal.build("/dest").withPrefix(Space.build(" ")),
                         Markers.EMPTY,
-                        Space.build("\n")
+                        Space.NEWLINE
                 )
         ).withEof(Space.EMPTY);
 
@@ -448,7 +448,7 @@ class DockerfilePrinterTest {
                             Docker.Literal.build("curl -f http://localhost/ || exit 1").withPrefix(Space.build(" "))
                         ),
                         Markers.EMPTY,
-                        Space.build("\n")
+                        Space.NEWLINE
                 )
         ).withEof(Space.EMPTY);
 
@@ -468,7 +468,7 @@ class DockerfilePrinterTest {
                         List.of(),
                         List.of(),
                         Markers.EMPTY,
-                        Space.build("\n")
+                        Space.NEWLINE
                 )
         ).withEof(Space.EMPTY);
 
@@ -481,7 +481,7 @@ class DockerfilePrinterTest {
     @Test
     void visitShell() {
         Docker.Document doc = Docker.Document.build(
-                Docker.Shell.build("sh", "-c").withEol(Space.build("\n"))
+                Docker.Shell.build("sh", "-c").withEol(Space.NEWLINE)
         ).withEof(Space.EMPTY);
 
         String expected = """

--- a/src/test/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinterTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinterTest.java
@@ -273,8 +273,7 @@ class DockerfilePrinterTest {
                         Tree.randomId(),
                         Space.EMPTY,
                         List.of(
-                                DockerRightPadded.build(
-                                        Docker.Option.build("--keep-git-dir", "false"))
+                            Docker.Option.build("--keep-git-dir", "false")
                         ),
                         List.of(
                             Docker.Literal.build("https://example.com/archive.zip").withPrefix(Space.build(" "))
@@ -299,18 +298,12 @@ class DockerfilePrinterTest {
                         Tree.randomId(),
                         Space.EMPTY,
                         List.of(
-                                DockerRightPadded.build(
-                                        Docker.Option.build("--chown", "user:group"))
+                            Docker.Option.build("--chown", "user:group")
                         ),
                         List.of(
-                                DockerRightPadded.build(
-                                        Docker.Literal.build("src").withPrefix(Space.build(" "))
-                                )
+                            Docker.Literal.build("src").withPrefix(Space.build(" "))
                         ),
-                        DockerRightPadded.build(
-                                Docker.Literal.build("/dest").withPrefix(Space.build(" ")
-                            )
-                        ),
+                        Docker.Literal.build("/dest").withPrefix(Space.build(" ")),
                         Markers.EMPTY,
                         Space.build("\n")
                 )

--- a/src/test/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinterTest.java
+++ b/src/test/java/com/github/jimschubert/rewrite/docker/tree/DockerfilePrinterTest.java
@@ -445,9 +445,7 @@ class DockerfilePrinterTest {
                                 )
                         ),
                         List.of(
-                                DockerRightPadded.build(
-                                        Docker.Literal.build("curl -f http://localhost/ || exit 1").withPrefix(Space.build(" "))
-                                )
+                            Docker.Literal.build("curl -f http://localhost/ || exit 1").withPrefix(Space.build(" "))
                         ),
                         Markers.EMPTY,
                         Space.build("\n")


### PR DESCRIPTION
Still KeyArgs and Port remain. I'll need to review these once again, possibly moving prefix and trailing spaces to a separate type, or just ensuring those two include the same conventions.