### PR TITLE
fix: clear line continuation handling after a multiline instruction

### DIFF
--- a/src/main/java/com/github/jimschubert/rewrite/docker/internal/ParserState.java
+++ b/src/main/java/com/github/jimschubert/rewrite/docker/internal/ParserState.java
@@ -32,6 +32,7 @@ public class ParserState {
         prefix = Space.EMPTY;
         rightPadding = Space.EMPTY;
         escapeChar = '\\';
+        isContinuation = false;
     }
 
     String getEscapeString() {


### PR DESCRIPTION
This fixes an issue when there was a multi-line instruction, that special handling wasn't immediately cleared, causing instructions literals to get combined.